### PR TITLE
add version to monorepo root package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "private": true,
+  "version": "0.0.0",
   "type": "module",
   "workspaces": [
     "packages/interface",


### PR DESCRIPTION
Before

```
bengo@bengo ~/ucanto-name-system ⚡  yarn add @ucanto/core@https://github.com/web3-storage/ucanto#refs/heads/feat/monorepo&workspace=@ucanto/core 
[1] 18078
yarn add v1.22.18
info No lockfile found.
warning package-lock.json found. Your project contains lock files generated by tools other than Yarn. It is advised not to mix package managers in order to avoid resolution inconsistencies caused by unsynchronized lock files. To clear this warning, remove package-lock.json.
[1/5] 🔍  Validating package.json...
[2/5] 🔍  Resolving packages...
warning tslint@6.1.3: TSLint has been deprecated in favor of ESLint. Please see https://github.com/palantir/tslint/issues/4534 for more information.
error Can't add "@ucanto/core": invalid package version undefined.
info Visit https://yarnpkg.com/en/docs/cli/add for documentation about this command.
```

After

```
⚡  yarn add @ucanto/core@https://github.com/gobengo/ucanto#refs/heads/feat/monorepo&workspace=@ucanto/core
# ...
✨  Done in 31.99s.

[1]  + done       yarn add 
```