### PR TITLE
feat: cherry pick changes from uploads-v2 demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ dist
 .nyc_output
 tmp
 node_modules
+.env

--- a/Readme.md
+++ b/Readme.md
@@ -1,257 +1,285 @@
 # ucanto
 
-(u)canto is a library for [UCAN][] based [RPC][] which provides:
+(u)canto is a library for [UCAN][] based [RPC][] that provides:
 
-1. A system for defining services as a map of UCAN [capability][] handlers.
-2. A runtime for executing capabilities through UCAN [invocations][].
-3. A pluggable transport layer.
-4. A [capability][] based routing system.
-5. Batched invocation with precise type inference.
-
+1. A declarative system for defining capabilities (roughly equivalet of HTTP
+   routes in REST).
+1. A system for binding [capability][] handles (a.k.a providers) to form services with built-in routing.
+1. UCAN validation system.
+1. Runtime for executing UCAN capability [invocations][].
+1. A pluggable transport layer.
+1. Clien supporting batched invocations and full type inference.
 
 > the name ucanto is a word play on UCAN and canto (one of the major divisions of a long poem)
 
+## Quick sample
 
-## High level overview
+To get a taste of the libary we will build up a "filesystem" service, in which:
+
+1. Top level paths are [did:key][] identifiers, here on referred as (user) drives.
+1. Drives are owned by users holding a private key corresponding to the [did:key][] of the drive.
+1. Drive owners could mutate filesystem with-in their drives path and delegate that ability to others.
+
+### Capabilities
+
+The very first thing we want to do is define set of capabilities our service will provide. Each (cap)[ability][] MUST:
+
+1. Have a `can` field denoting an _action_ it can perform.
+2. Have a `with` URI denoting _resource_ it can perform that action on.
+3. Be comparable to other capabilities _(with set semantics, as in does capability `a` includes capability `b` ?)_
+
+Lets define `file/link` capability, where resources are identified via `file:` URLs and MAY contain `link` to be mapped to a given path.
+
+```ts
+import { capability, URI, Link, Failure } from "@ucanto/server"
+
+const Add = capability({
+  can: "file/link",
+  with: URI.match({ protocol: "file:" }),
+  caveats: { link: Link },
+  derives: (claimed, delegated) =>
+    // Can be derived if claimed capability path is contained in the delegated
+    // capability path.
+    claimed.uri.href.startsWith(ensureTrailingDelimiter(delegated.uri.href)) ||
+    new Failure(`Notebook ${claimed.uri} is not included in ${delegaed.uri}`),
+})
+
+const ensureTrailingDelimiter = uri => (uri.endsWith("/") ? uri : `${uri}/`)
+```
+
+> Please note that library gurantees that both `claimed` and `delegated` capabilty will have `{can: "file/link", with: string, uri: URL, caveats: { link?: CID }}`
+> type inferred from the definition.
+>
+> We will explore more complicated case later where capability may be derived from a different capability or even a set.
 
 ### Services
 
-This library defines a "service" as a hierarchical mapping of (cap)[ability][] _(The `can` field of the capability)_ to a handler. To make it more clear, lets define a simple service that provides `{ can: "intro/echo", with: "data:*" }` capability which echoes back the message, and `{ can: "math/sqrt", with: "*", n: number }` capability which returns square root of a given number.
+Now that we have a `file/link` capability we can define a service providing it:
 
 ```ts
-import type {Invocation, Result} from "ucanto"
+import { provide, Failure, MalformedCapability } from "@ucanto/server"
 
-type Echo = {
-  can: "intro/echo"
-  with: string
-}
-
-export const echo = async({ capability }: Invocation<Echo>):Promise<Result<string, InvalidInputError>> => {
-  const result = !capability.with.startsWith('data:')
-    ? new InvalidInputError(`Capability "intro/echo" expects with to be a data URL, instead got ${capability.with}`)
-    : !capability.with.startsWith('data:text/plain,')
-    ? new InvalidInputError(`Capability "intro/echo" currently only support data URLs in text/plain encoding`)
-    : { ok: true, value: capability.with.slice('data:text/plain,'.length) }
-      
-  return result
-}
-
-export const sqrt = async({ capabality }:Invocation<Sqrt>):Promise<Result<number, InvalidInputError>> => {
-  const result = capability.n < 0
-    ? new InvalidInputError(`Capability "math/sqrt" only operates on positive numbers, instead got ${capability.n}`)
-    : { ok: true, Math.sqrt(capability.n) }
-}
-
-
-// heirarchical mapping of (cap)abilities with corresponding handlers
-// 'intro/echo' -> .intro.echo
-// 'math/sqrt' -> .math.sqrt
-export const service = {
-  intro: { echo },
-  math: { sqrt }
-}
-
-
-class InvalidInputError extends Error {
-  constructor(input) {
-     super(`Invalid input: ${input}`)
-  }
-}
-```
-
-There are few requirements that all handlers MUST meet:
-
-1. Handler takes a single argument of type `Service.Invocation<Capability>` which is a deserialized representation of a UCAN invocation with a **single** concrete capability. Although the invocation must take a single capability, you can use a [type union][] to accept multiple types of input data.
-   > Right now it MUST have `can` field but that requirement may be removed in the future.
-2. Handler MUST return `Result` type
-   > Errors happen, and it's best to specify what kind in types. While you can simply do `Result<T, Error>`, it's recommended to be more specific.
-   
- Please note:
- 
- 1. We have not done any UCAN validation here to keep things simple _(but also "intro/echo" capability can be self issued :P)_. That is something you MUST do in your handler though.
- 2. We defined our service as `{ intro: { echo }, math: { sqrt } }` which maps with corresponding (cap)abilities and provides definitions for the routing system.
- 
- 
- ### Transport
- 
- The library provides a pluggable transport architecture so you can expose a service in various transport encodings. To do so you have to provide:
- 
- 1. `decoder` that will take `{ headers: Record<string, string>, body: Uint8Array }` object and decode it into `{ invocations: Invocation[] }`.
- 2. `encoder` that will take `unknown[]` (corresponding to values returned by handlers) and encode it into `{ headers: Record<string, string>, body: Uint8Array }`.
- 3. `service` implementation
- 
- > Note that the actual encoder / decoder types are more complicated as they capture capability types, the number of invocations, and corresponding return types. This allows them to provide good type inference. But ignoring those details, that is what they are in a nutshell.
- 
- In the example below we create a server which will take invocations encoded in [CAR][] format and produce responses encoded in [DAG-CBOR][] format. There are a few other options provided by tbe library, and you could also bring your own.
- 
- ```ts
-import * as Server from "ucanto/src/server.js"
-import * as Transport from "ucanto/src/transport.js"
-
-const server = Server.create({
-  service,
-  decoder: Transport.CAR,
-  encoder: Transport.CBOR,
-})
- ```
- 
- ### Routing
- 
- The server defined above can:
- 
- 1. Take requests in `{ headers: Record<string, string>, body: Uint8Array }` format.
- 1. Decode them into `Invocation`s.
- 1. Route and execute corresponding (cap)[ability][] handler.
- 1. Encode results back into ``{ headers: Record<string, string>, body: Uint8Array }` format.
- 
- All you need to do is simply pass the request:
- 
- ```js
- export const handler = async (payload:{headers:Record<string, string>, body:Uint8Array}):Promise<{headers:Record<string, string>, body:Uint8Array}> =>
-   server.request(payload)
- ```
- 
- **Please note:** this library intentionally does not deal with any networking, so that you could plug it into whatever runtime you need as long as you can represent request responses as `{ headers: Record<string, string>, body: Uint8Array }`
- 
- > Streaming is not currently supported, but may be added in the future.
- 
- 
- ## Client
- 
-Client implementation can be used to issue and execute UCAN invocations. Here is an example of invoking capabilities defined by our service earlier:
-
-```ts
-import * as Client from "ucanto/src/client.js"
-import * as DID from "@ipld/dag-ucan"
-import { keypair } from "ucans"
-
-const service = DID.parse("did:key:zDnaerDaTF5BXEavCrfRZEk316dpbLsfPDZ3WJ5hRTPFU2169")
-
-// did:key:z6Mkk89bC3JrVqKie71YEcc5M1SMVxuCgNx6zLZ8SYJsxALi
-const alice = keypair.EdKeypair.fromSecretKey("U+bzp2GaFQHso587iSFWPSeCzbSfn/CbNHEz7ilKRZ1UQMmMS7qq4UhTzKn3X9Nj/4xgrwa+UqhMOeo4Ki8JUw==")
-
-
-const demo1 = async (connection) => {
-  const hello = await Client.invoke({
-    issuer: alice,
-    audience: service
-    can: "intro/echo",
-    with: "data:text/plain,hello world"
+const service = (context: { store: Map<string, string> }) => {
+  const add = provide(Add, ({ capability, invocation }) => {
+    store.set(capability.uri.href, capability.caveats.link)
+    return {
+      with: capability.with,
+      link: capability.caveats.link,
+    }
   })
-  
-  const result = await hello.execute(connection)  
-  if (result.ok) {
-    console.log("got echo back", result.value)
-  } else {
-    console.error("oops", result)
-  }
+
+  return { file: { add } }
 }
 ```
 
-Note that the client will get complete type inference as long as `connection` captures a type of the service on the other side of the wire.
+Used `provide` building block will take care of associating a handler to the a
+given capability and performing necessary UCAN validation steps when `add` is
+invoked.
 
 ### Transport
 
-Just like the server, the client has a pluggable transport layer which you provide when you create a connection. The transport layer consists of:
- 
- 1. `encoder` takes `{ invocations: IssuedInvocation[] }` objects and turn them into `{ headers: Record<string, string>, body: Uint8Array }`.
- 2. `decoder` takes `{ headers: Record<string, string>, body: Uint8Array }` and turns it into `unknown[]` (that correspond to return values for invocations).
- 3. `channel` transport channel that takes request delivers it to the server and returns promise of the response when one is received from the server, which looks like
- `{ request(payload:{headers: Record<string, string>, body: Uint8Array}):Promise<{headers: Record<string, string>, body: Uint8Array}> }`
- 
- We could create an in-process connection with our service simply by providing service as a channel:
- 
- ```ts
+The library provides a pluggable transport architecture so you can expose a service in various content encodings. To do so you have to provide:
+
+1.  `decoder` that will take `{ headers: Record<string, string>, body: Uint8Array }` object and decode it into `{ invocations: Invocation[] }`.
+2.  `encoder` that will take `unknown[]` (corresponding to values returned by handlers) and encode it into `{ headers: Record<string, string>, body: Uint8Array }`.
+
+> Note that the actual encoder / decoder types are more complicated as they capture capability types, the number of invocations, and corresponding return types. This allows them to provide good type inference. But ignoring those details, that is what they are in a nutshell.
+
+Library comes with several transport layer codecs you can pick from, but you can also bring one yourself. Below we will take invocations encoded in [CAR][] format and produce responses encoded in [DAG-CBOR][] format:
+
+```ts
+import * as Server from "@ucanto/server"
+import * as CAR from "@ucanto/transport/car"
+import * as CBOR from "@ucanto/transport/cbor"
+import { SigningAuthority } from "@ucanto/authority"
+import * as HTTP from "node:http"
+import * as Buffer from "node:buffer"
+
+export const server = (context { store = new Map() } : { store: Map<string, string> }) =>
+  Server.create({
+    id: await SigningAuthority.derive(process.env.SERVICE_SECRET),
+    service: service(context),
+    decoder: CAR,
+    encoder: CBOR,
+
+    // We tell server that capability can be self-issued by a drive owner
+    canIssue: (capability, issuer) => {
+      if (capability.uri.protocol === "file:") {
+        const [did] = capability.uri.pathname.split("/")
+        return did === issuer
+      }
+      return false
+    },
+  })
+```
+
+> Please note that server does not do HTTP as bindings may differ across runtimes, so it is up to you to plug one in.
+
+In nodejs we could expose our service as follows:
+
+```ts
+
+export const listen = ({ port = 8080, context = new Map() }) => {
+  const fileServer = server(context)
+
+  HTTP.createServer(async (request, response), => {
+    const chunks = []
+    for await (const chunk of request) {
+      chunks.push(chunk)
+    }
+
+    const { headers, body } = await fileServer.request({
+      headers: request.headers,
+      body: Buffer.concat(chunks)
+    })
+
+    response.writeHead(200, headers)
+    response.write(body)
+    response.end()
+  }).listen(port)
+}
+```
+
+## Client
+
+Client can be used to issue and execute UCAN invocations. Here is an example of
+invoking `file/link` capability we've defined earlier
+
+```ts
+import * as Client from "@ucanto/client"
+import { SigningAuthority, Authority } from "@ucanto/authority"
+import { CID } from "multiformats"
+
+
+// Service will have a well known DID
+const service = Authority.parse(process.env.SERVICE_ID)
+// Client keypair
+const issuer = SigningAuthority.parse(process.env.MY_KEPAIR)
+
+
+const demo1 = async (connection) => {
+  const me = await Client.invoke({
+    issuer: alice,
+    audience: service
+    can: "file/link",
+    with: `file://${issuer.did()}/me/about`,
+    link: CID.parse(process.env.ME_CID)
+  })
+
+  const result = await me.execute(connection)
+  if (result.error) {
+    console.error("oops", result)
+  } else {
+    console.log("file got linked", result.link.toString())
+  }
+}
+```
+
+> Note that the client will get full type inference on when `connection` captures a type of the service on the other side of the wire.
+
+### Connection
+
+Just like the server, the client has a pluggable transport layer which you provide when you create a connection. We could create an in-process connection with our service simply by providing service as a channel:
+
+```ts
 const connection = Client.connect({
-  encoder: Transport.CAR,  // encode as CAR because server decods from car
+  encoder: Transport.CAR, // encode as CAR because server decods from car
   decoder: Transport.CBOR, // decode as CBOR because server encodes as CBOR
-  channel: server,         // simply pass the server
+  channel: server(), // simply pass the server
 })
- ```
- 
- In practice you probably would want client/server communication to happen across a wire, or at least across processes. You can bring your own transport channel, or choose an existing one. For example:
- 
- ```ts
-import * as Transport from "ucanto/src/transport.js"
+```
 
- const connection = Client.connect({
-  encoder: Transport.CAR,  // encode as CAR because server decodes from car
+In practice you probably would want client/server communication to happen across the wire, or at least across processes. You can bring your own transport channel, or choose an existing one. For example:
+
+```ts
+import * as HTTP from "@ucanto/transport/http"
+import * as CAR from "@ucanto/transport/car"
+import * as CBOR from "@ucanto/transport/cbor"
+
+const connection = Client.connect({
+  encoder: Transport.CAR, // encode as CAR because server decodes from car
   decoder: Transport.CBOR, // decode as CBOR because server encodes as CBOR
-  /** @type {Transport.Channel<typeof service>} */
-  channel: Transport.HTTP.open({ url: new URL(process.env.SERVICE_URL) }) // simple `fetch` wrapper 
+  /** @type {Transport.Channel<ReturnType<typeof service>>} */
+  channel: Transport.HTTP.open({ url: new URL(process.env.SERVICE_URL) }),
 })
- ```
+```
 
-> Note: That in that case, you ned to provide type annotations, so the client can provide inference for requests and return types
+> Note: That in the seconnd example you need to provide a type annotations, so that client can infer what capabilities can be invoked and what the return types it will correspond to.
 
 ### Batching & Proof chains
 
 The library supports batch invocations and takes care of all the nitty gritty details when it comes to UCAN delegation chains, specifically taking chains apart to encode as blocks in CAR and putting them back together into a chain on the other side. All you need to do is provide a delegation in the proofs:
 
 ```ts
-import * as Client from "ucanto/src/client.js"
-import * as DID from "@ipld/dag-ucan"
-import { keypair } from "ucans"
+import { SigningAuthority, Authority } from "@ucanto/authority"
+import * as Client from "@ucanto/client"
+import { CID } from "multiformats"
 
-const service = DID.parse("did:key:zDnaerDaTF5BXEavCrfRZEk316dpbLsfPDZ3WJ5hRTPFU2169")
+const service = Authority.parse(process.env.SERVICE_DID)
+const alice = SigningAuthority.parse(process.env.ALICE_KEYPAIR)
+const bob = SigningAuthority.parse(process.env.BOB_KEYPAIR)
 
-// did:key:z6Mkk89bC3JrVqKie71YEcc5M1SMVxuCgNx6zLZ8SYJsxALi
-const alice = keypair.EdKeypair.fromSecretKey("U+bzp2GaFQHso587iSFWPSeCzbSfn/CbNHEz7ilKRZ1UQMmMS7qq4UhTzKn3X9Nj/4xgrwa+UqhMOeo4Ki8JUw==")
-// did:key:z6MkffDZCkCTWreg8868fG1FGFogcJj5X6PY93pPcWDn9bob
-const bob = keypair.EdKeypair.fromSecretKey("G4+QCX1b3a45IzQsQd4gFMMe0UB1UOx9bCsh8uOiKLER69eAvVXvc8P2yc4Iig42Bv7JD2zJxhyFALyTKBHipg==")
-
-
-const demo2 = async (connection) => {
-  const bye = await Client.invoke({
+const demo2 = async connection => {
+  // Alice delegates capability to mutate FS under bob's namespace
+  const proof = await Client.delegate({
     issuer: alice,
-    audience: service
-    can: "intro/echo",
-    with: "data:text/plain,bye"
+    audience: bob.authority,
+    capabilities: [
+      {
+        can: "file/link",
+        with: `file://${alice.did()}/friends/${bob.did()}/`,
+      },
+    ],
   })
-  
-  const sqrt = (n) => Client.invoke({
-    issuer: alice,
+
+  const aboutBob = Client.invoke({
+    issuer: bob,
     audience: service,
-    can: "math/sqrt",
-    with: alice.did(),
-    n,
-    proofs: [UCAN.parse(process.env.UCAN)]
+    capability: {
+      can: "file/link",
+      with: `file://${alice.did()}/friends/${bob.did()}/about`,
+      link: CID.parse(process.env.BOB_CID),
+    },
   })
-  
-  const [r1, r2] = batch(bye, await sqrt(9)).execute(connection)
-  
-  if (r1.ok) {
-    console.log("got echo back", r1.value)
-  } else {
+
+  const aboutMallory = Client.invoke({
+    issuer: bob,
+    audience: service,
+    capability: {
+      can: "file/link",
+      with: `file://${alice.did()}/friends/${MALLORY_DID}/about`,
+      link: CID.parse(process.env.MALLORY_CID),
+    },
+  })
+
+  const [bobResult, malloryResult] = connection.execute([
+    aboutBob,
+    aboutMallory,
+  ])
+
+  if (bobResult.error) {
     console.error("oops", r1)
-  }
-  
-  if (r2.ok) {
-    console.log("got sqrt", r2.value)
   } else {
+    console.log("about bob is linked", r1)
+  }
+
+  if (malloryResult.error) {
     console.log("oops", r2)
+  } else {
+    console.log("about mallory is linked", r2)
   }
 }
 ```
 
-## Future
+> In the example above first invocation will succeed, but second will not becasue has not been granted capability to mutate other namespace. Also note that both invocations are send in a single request.
 
-Intentions are that in the future we may provide a more powerful GraphQL inspired invocation interface along the lines of:
-
-```ts
-Client.query({
-  r1: select({ intro: { echo: { with: "data:text/plain,hello beautiful" } } }),
-  // pass a request and specify which fields to select
-  r2: select({ store: { add: { with: alice.did(), link: cid } }, { url: true, status: true })
-})
-```
- 
-
-[UCAN]:https://github.com/ucan-wg/spec/
-[RPC]:https://en.wikipedia.org/wiki/Remote_procedure_call
-[capability]:https://github.com/ucan-wg/spec/#23-capability
-[invocations]:https://github.com/ucan-wg/spec/#28-invocation
-[ability]:https://github.com/ucan-wg/spec/#3242-ability
-[type union]:https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#union-types
-[CAR]:https://ipld.io/specs/transport/car/carv1/
-[DAG-CBOR]:https://ipld.io/specs/codecs/dag-cbor/
+[ucan]: https://github.com/ucan-wg/spec/
+[rpc]: https://en.wikipedia.org/wiki/Remote_procedure_call
+[capability]: https://github.com/ucan-wg/spec/#23-capability
+[invocations]: https://github.com/ucan-wg/spec/#28-invocation
+[ability]: https://github.com/ucan-wg/spec/#3242-ability
+[type union]: https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#union-types
+[car]: https://ipld.io/specs/transport/car/carv1/
+[dag-cbor]: https://ipld.io/specs/codecs/dag-cbor/
+[cid]: https://docs.ipfs.io/concepts/content-addressing/
+[did:key]: https://w3c-ccg.github.io/did-method-key/

--- a/Readme.md
+++ b/Readme.md
@@ -150,20 +150,20 @@ import * as Client from "@ucanto/client"
 import { SigningAuthority, Authority } from "@ucanto/authority"
 import { CID } from "multiformats"
 
-
 // Service will have a well known DID
 const service = Authority.parse(process.env.SERVICE_ID)
 // Client keypair
 const issuer = SigningAuthority.parse(process.env.MY_KEPAIR)
 
-
-const demo1 = async (connection) => {
+const demo1 = async connection => {
   const me = await Client.invoke({
     issuer: alice,
-    audience: service
-    can: "file/link",
-    with: `file://${issuer.did()}/me/about`,
-    link: CID.parse(process.env.ME_CID)
+    audience: service,
+    capability: {
+      can: "file/link",
+      with: `file://${issuer.did()}/me/about`,
+      link: CID.parse(process.env.ME_CID),
+    },
   })
 
   const result = await me.execute(connection)

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ucanto",
+  "name": "ucanto",
   "private": true,
   "type": "module",
   "workspaces": [

--- a/packages/authority/package.json
+++ b/packages/authority/package.json
@@ -19,7 +19,6 @@
   },
   "homepage": "https://github.com/web3-storage/ucanto",
   "scripts": {
-    "prepare": "tsc --build",
     "test:web": "playwright-test test/**/*.spec.js --cov && nyc report",
     "test:node": "c8 --check-coverage --branches 100 --functions 100 --lines 100 mocha test/**/*.spec.js",
     "test": "npm run test:node",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -21,7 +21,6 @@
   },
   "homepage": "https://github.com/web3-storage/ucanto",
   "scripts": {
-    "prepare": "tsc --build",
     "test:web": "playwright-test test/**/*.spec.js --cov && nyc report",
     "test:node": "c8 --check-coverage --branches 100 --functions 100 --lines 100 mocha test/**/*.spec.js",
     "test": "npm run test:node",

--- a/packages/client/test/services/account.js
+++ b/packages/client/test/services/account.js
@@ -94,7 +94,7 @@ const associate = (accounts, from, to, proof, create) => {
   // account and link all them together.
   if (!fromAccount && !toAccount) {
     if (create) {
-      const account = the(`did:cid:${proof}`)
+      const account = the(`did:ipld:${proof}`)
       accounts.set(to, { account, proof })
       accounts.set(from, { account, proof })
     } else {
@@ -105,7 +105,7 @@ const associate = (accounts, from, to, proof, create) => {
   } else if (fromAccount) {
     accounts.set(to, { account: fromAccount, proof })
   } else if (fromAccount !== toAccount) {
-    const account = the(`did:cid:${proof}`)
+    const account = the(`did:ipld:${proof}`)
     accounts.set(toAccount, { account, proof })
     accounts.set(fromAccount, { account, proof })
   }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,7 +21,6 @@
   },
   "homepage": "https://github.com/web3-storage/ucanto",
   "scripts": {
-    "prepare": "tsc --build",
     "test:web": "playwright-test test/*.spec.js --cov && nyc report",
     "test:node": "c8 --check-coverage --branches 100 --functions 100 --lines 100 mocha test/*.spec.js",
     "test": "npm run test:node",

--- a/packages/interface/package.json
+++ b/packages/interface/package.json
@@ -19,7 +19,6 @@
   },
   "homepage": "https://github.com/web3-storage/ucanto",
   "scripts": {
-    "prepare": "tsc --build",
     "typecheck": "tsc --build"
   },
   "dependencies": {

--- a/packages/interface/src/capability.ts
+++ b/packages/interface/src/capability.ts
@@ -125,7 +125,7 @@ export interface View<M extends Match> extends Matcher<M>, Selector<M> {
    */
   derive<T extends ParsedCapability>(
     options: DeriveSelector<M, T>
-  ): CapabilityParser<DerivedMatch<T, M>>
+  ): TheCapabilityParser<DerivedMatch<T, M>>
 }
 
 export interface TheCapabilityParser<M extends Match<ParsedCapability>>
@@ -233,14 +233,20 @@ export interface ParsedCapability<
   caveats: C
 }
 
-export type InferCaveats<C> = {
-  [Key in keyof C]: C[Key] extends Decoder<unknown, infer T, infer _>
+export type InferCaveats<C> = InferRequiredCaveats<C> & InferOptionalCaveats<C>
+
+export type InferOptionalCaveats<C> = {
+  [Key in keyof C as C[Key] extends Decoder<any, infer _ | undefined, any>
+    ? Key
+    : never]?: C[Key] extends Decoder<unknown, infer T | undefined, infer _>
     ? T
-    : C[Key] extends Parser<unknown, infer T, infer _X>
-    ? T
-    : // : C[Key] extends (input: unknown) => infer T
-      // ? Exclude<T, Failure>
-      never
+    : never
+}
+
+export type InferRequiredCaveats<C> = {
+  [Key in keyof C as C[Key] extends Decoder<any, infer _ | undefined, any>
+    ? never
+    : Key]: C[Key] extends Decoder<unknown, infer T, infer _> ? T : never
 }
 
 export interface Descriptor<A extends Ability, C extends Caveats> {

--- a/packages/interface/src/capability.ts
+++ b/packages/interface/src/capability.ts
@@ -81,8 +81,8 @@ export type InvalidCapability = UnknownCapability | MalformedCapability
 export interface DerivedMatch<T, M extends Match>
   extends Match<T, M | DerivedMatch<T, M>> {}
 
-export interface DeriveSelector<M extends Match, T> {
-  to: MatchSelector<DirectMatch<T>>
+export interface DeriveSelector<M extends Match, T extends ParsedCapability> {
+  to: TheCapabilityParser<DirectMatch<T>>
   derives: Derives<T, M["value"]>
 }
 
@@ -128,12 +128,9 @@ export interface View<M extends Match> extends Matcher<M>, Selector<M> {
   ): CapabilityParser<DerivedMatch<T, M>>
 }
 
-export interface TheCapabilityParser<
-  A extends Ability = Ability,
-  C extends Caveats = Caveats,
-  M extends CapabilityMatch<A, C> = CapabilityMatch<A, C>
-> extends CapabilityParser<M> {
-  can: A
+export interface TheCapabilityParser<M extends Match<ParsedCapability>>
+  extends CapabilityParser<M> {
+  readonly can: M["value"]["can"]
 }
 
 export interface CapabilityParser<M extends Match = Match> extends View<M> {

--- a/packages/interface/src/lib.ts
+++ b/packages/interface/src/lib.ts
@@ -165,7 +165,9 @@ export interface ServiceMethod<
   O,
   X extends { error: true }
 > {
-  (input: Invocation<I>, context: InvocationContext): Await<Result<O, X>>
+  (input: Invocation<I>, context: InvocationContext): Await<
+    Result<O, X | InvocationError>
+  >
 }
 
 export type InvocationError =

--- a/packages/interface/src/lib.ts
+++ b/packages/interface/src/lib.ts
@@ -309,7 +309,7 @@ export interface ConnectionView<T> extends Connection<T> {
   ): Await<InferServiceInvocations<I, T>>
 }
 
-export interface Server<T> {
+export interface TranpsortOptions {
   /**
    * Request decoder which is will be used by a server to decode HTTP Request
    * into an invocation `Batch` that will be executed using a `service`.
@@ -321,27 +321,33 @@ export interface Server<T> {
    * request.
    */
   readonly encoder: Transport.ResponseEncoder
+}
 
+export interface ValidatorOptions {
   /**
    * Takes authority parser that can be used to turn an `UCAN.Identity`
    * into `Ucanto.Authority`.
    */
   readonly authority?: AuthorityParser
 
+  readonly canIssue?: CanIssue["canIssue"]
+  readonly my?: InvocationContext["my"]
+  readonly resolve?: InvocationContext["resolve"]
+}
+
+export interface ServerOptions extends TranpsortOptions, ValidatorOptions {
   /**
    * Service DID which will be used to verify that received invocation
    * audience matches it.
    */
   readonly id: Identity
+}
 
+export interface Server<T> extends ServerOptions {
   /**
    * Actual service providing capability handlers.
    */
   readonly service: T
-
-  readonly canIssue?: CanIssue["canIssue"]
-  readonly my?: InvocationContext["my"]
-  readonly resolve?: InvocationContext["resolve"]
 }
 
 export interface ServerView<T> extends Server<T>, Transport.Channel<T> {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -20,7 +20,6 @@
   },
   "homepage": "https://github.com/web3-storage/ucanto",
   "scripts": {
-    "prepare": "tsc --build",
     "test:web": "playwright-test test/**/*.spec.js --cov && nyc report",
     "test:node": "c8 --check-coverage --branches 100 --functions 100 --lines 100 mocha test/**/*.spec.js",
     "test": "npm run test:node",

--- a/packages/server/src/api.ts
+++ b/packages/server/src/api.ts
@@ -24,7 +24,7 @@ export interface ProviderContext<
   C extends API.Caveats = API.Caveats
 > {
   capability: API.ParsedCapability<A, API.InferCaveats<C>>
-  invocation: API.Invocation<API.Capability<A, R>>
+  invocation: API.Invocation<API.Capability<A, R> & API.InferCaveats<C>>
 
   context: API.InvocationContext
 }

--- a/packages/server/src/handler.js
+++ b/packages/server/src/handler.js
@@ -8,13 +8,13 @@ import { access } from "@ucanto/validator"
  * @template {unknown} U
  * @param {API.TheCapabilityParser<API.CapabilityMatch<A, C>>} capability
  * @param {(input:API.ProviderContext<A, R, C>) => API.Await<U>} handler
- * @returns {API.ServiceMethod<API.Capability<A, R>, Exclude<U, {error:true}>, Exclude<U, Exclude<U, {error:true}>>|API.InvocationError>}
+ * @returns {API.ServiceMethod<API.Capability<A, R> & API.InferCaveats<C>, Exclude<U, {error:true}>, Exclude<U, Exclude<U, {error:true}>>>}
  */
 
 export const provide =
   (capability, handler) =>
   /**
-   * @param {API.Invocation<API.Capability<A, R>>} invocation
+   * @param {API.Invocation<API.Capability<A, R> & API.InferCaveats<C>>} invocation
    * @param {API.InvocationContext} options
    * @return {Promise<API.Result<Exclude<U, {error:true}>, Exclude<U, Exclude<U, {error:true}>>|API.InvocationError>>}
    */

--- a/packages/server/src/handler.js
+++ b/packages/server/src/handler.js
@@ -6,7 +6,7 @@ import { access } from "@ucanto/validator"
  * @template {API.Caveats} C
  * @template {API.Resource} R
  * @template {unknown} U
- * @param {API.TheCapabilityParser<A, C>} capability
+ * @param {API.TheCapabilityParser<API.CapabilityMatch<A, C>>} capability
  * @param {(input:API.ProviderContext<A, R, C>) => API.Await<U>} handler
  * @returns {API.ServiceMethod<API.Capability<A, R>, Exclude<U, {error:true}>, Exclude<U, Exclude<U, {error:true}>>|API.InvocationError>}
  */

--- a/packages/server/src/lib.js
+++ b/packages/server/src/lib.js
@@ -1,5 +1,4 @@
 export * from "./server.js"
-export * from "./handler.js"
+// @ts-ignore
 export * from "./api.js"
-
-export { InvocationError } from "./server.js"
+export * from "./handler.js"

--- a/packages/server/src/server.js
+++ b/packages/server/src/server.js
@@ -1,6 +1,6 @@
 import * as API from "@ucanto/interface"
 export * from "@ucanto/interface"
-import { InvalidAudience, UnavailableProof } from "@ucanto/validator"
+import { InvalidAudience } from "@ucanto/validator"
 import { Authority } from "@ucanto/authority"
 export {
   capability,

--- a/packages/server/src/server.js
+++ b/packages/server/src/server.js
@@ -2,7 +2,13 @@ import * as API from "@ucanto/interface"
 export * from "@ucanto/interface"
 import { InvalidAudience, UnavailableProof } from "@ucanto/validator"
 import { Authority } from "@ucanto/authority"
-export { capability, URI, Link, Failure } from "@ucanto/validator"
+export {
+  capability,
+  URI,
+  Link,
+  Failure,
+  MalformedCapability,
+} from "@ucanto/validator"
 
 /**
  * Creates a connection to a service.

--- a/packages/server/test/service/access.js
+++ b/packages/server/test/service/access.js
@@ -17,7 +17,7 @@ const registerCapability = Server.capability({
 
 const linkCapability = Server.capability({
   can: "identity/link",
-  with: Server.URI.match({ protocol: "mailto:" }),
+  with: Server.URI,
   derives: (claimed, delegated) =>
     claimed.uri.href === delegated.uri.href ||
     new Server.Failure(
@@ -96,7 +96,7 @@ const associate = (accounts, from, to, proof, create) => {
   // account and link all them together.
   if (!fromAccount && !toAccount) {
     if (create) {
-      const account = /** @type {API.DID} */ (`did:cid:${proof}`)
+      const account = /** @type {API.DID} */ (`did:ipld:${proof}`)
       accounts.set(to, { account, proof })
       accounts.set(from, { account, proof })
     } else {
@@ -107,7 +107,7 @@ const associate = (accounts, from, to, proof, create) => {
   } else if (fromAccount) {
     accounts.set(to, { account: fromAccount, proof })
   } else if (fromAccount !== toAccount) {
-    const account = /** @type {API.DID} */ (`did:cid:${proof}`)
+    const account = /** @type {API.DID} */ (`did:ipld:${proof}`)
     accounts.set(toAccount, { account, proof })
     accounts.set(fromAccount, { account, proof })
   }

--- a/packages/transport/package.json
+++ b/packages/transport/package.json
@@ -21,7 +21,6 @@
   },
   "homepage": "https://github.com/web3-storage/ucanto",
   "scripts": {
-    "prepare": "tsc --build",
     "test:web": "playwright-test test/**/*.spec.js --cov && nyc report",
     "test:node": "c8 --check-coverage --branches 100 --functions 100 --lines 100 mocha test/**/*.spec.js",
     "test": "npm run test:node",

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -19,7 +19,6 @@
   },
   "homepage": "https://github.com/web3-storage/ucanto",
   "scripts": {
-    "prepare": "tsc --build",
     "test:web": "playwright-test test/**/*.spec.js --cov && nyc report",
     "test:node": "c8 --check-coverage --branches 90 --functions 80 --lines 90 mocha test/**/*.spec.js",
     "test": "npm run test:node",

--- a/packages/validator/src/capability.js
+++ b/packages/validator/src/capability.js
@@ -9,7 +9,7 @@ import {
 
 /**
  * @template {API.Ability} A
- * @template {API.Caveats} C
+ * @template {API.Caveats} [C={}]
  * @param {API.Descriptor<A, C>} descriptor
  * @returns {API.TheCapabilityParser<API.CapabilityMatch<A, C>>}
  */
@@ -62,7 +62,7 @@ class View {
   /**
    * @template {API.ParsedCapability} U
    * @param {API.DeriveSelector<M, U>} options
-   * @returns {API.CapabilityParser<API.DerivedMatch<U, M>>}
+   * @returns {API.TheCapabilityParser<API.DerivedMatch<U, M>>}
    */
   derive({ derives, to }) {
     return derive({ derives, to, from: this })

--- a/packages/validator/src/capability.js
+++ b/packages/validator/src/capability.js
@@ -11,7 +11,7 @@ import {
  * @template {API.Ability} A
  * @template {API.Caveats} C
  * @param {API.Descriptor<A, C>} descriptor
- * @returns {API.TheCapabilityParser<A, C, API.CapabilityMatch<A, C>>}
+ * @returns {API.TheCapabilityParser<API.CapabilityMatch<A, C>>}
  */
 export const capability = descriptor => new Capability(descriptor)
 
@@ -35,7 +35,7 @@ export const and = (...selectors) => new And(selectors)
  * @template {API.Match} M
  * @template {API.ParsedCapability} T
  * @param {API.DeriveSelector<M, T> & { from: API.MatchSelector<M> }} options
- * @returns {API.CapabilityParser<API.DerivedMatch<T, M>>}
+ * @returns {API.TheCapabilityParser<API.DerivedMatch<T, M>>}
  */
 export const derive = ({ from, to, derives }) => new Derive(from, to, derives)
 
@@ -97,7 +97,7 @@ class Unit extends View {
 /**
  * @template {API.Ability} A
  * @template {API.Caveats} C
- * @implements {API.TheCapabilityParser<A, C, API.CapabilityMatch<A, C>>}
+ * @implements {API.TheCapabilityParser<API.CapabilityMatch<A, C>>}
  * @extends {Unit<API.CapabilityMatch<A, C>>}
  */
 class Capability extends Unit {
@@ -220,14 +220,14 @@ class And extends View {
 /**
  * @template {API.ParsedCapability} T
  * @template {API.Match} M
- * @implements {API.CapabilityParser<API.DerivedMatch<T, M>>}
+ * @implements {API.TheCapabilityParser<API.DerivedMatch<T, M>>}
  * @extends {Unit<API.DerivedMatch<T, M>>}
  */
 
 class Derive extends Unit {
   /**
    * @param {API.MatchSelector<M>} from
-   * @param {API.MatchSelector<API.DirectMatch<T>>} to
+   * @param {API.TheCapabilityParser<API.DirectMatch<T>>} to
    * @param {API.Derives<T, M['value']>} derives
    */
   constructor(from, to, derives) {
@@ -235,6 +235,9 @@ class Derive extends Unit {
     this.from = from
     this.to = to
     this.derives = derives
+  }
+  get can() {
+    return this.to.can
   }
   /**
    * @param {API.Source} capability

--- a/packages/validator/src/lib.js
+++ b/packages/validator/src/lib.js
@@ -8,10 +8,11 @@ import {
   InvalidSignature,
   DelegationError,
   Failure,
+  MalformedCapability,
   li,
 } from "./error.js"
 
-export { Failure, UnavailableProof }
+export { Failure, UnavailableProof, MalformedCapability }
 
 export { capability } from "./capability.js"
 


### PR DESCRIPTION
1. Removes prepare scripts since git deps don't work on monorepos anyway.
2. Adds .env to .gitignore
3. Improves handling of optional caveats on capabilities.
4. Improves `provide` to support derived capabilities.
5. Updates some tests to map uploads-v2 better.