### PR TITLE
feat(ucanto): capability create / inovke methods

### DIFF
--- a/packages/client/src/lib.js
+++ b/packages/client/src/lib.js
@@ -1,7 +1,7 @@
-export * from './invoke.js'
 export * from './connection.js'
 
 export * from '@ucanto/interface'
-import { Delegation } from '@ucanto/core'
+import { Delegation, invoke } from '@ucanto/core'
 
 export const delegate = Delegation.delegate
+export { invoke }

--- a/packages/core/src/lib.js
+++ b/packages/core/src/lib.js
@@ -1,5 +1,6 @@
 export * as Delegation from './delegation.js'
 export { delegate, isDelegation } from './delegation.js'
+export { invoke } from './invocation.js'
 export {
   create as createLink,
   createV0 as createLegacyLink,

--- a/packages/core/test/invocation.spec.js
+++ b/packages/core/test/invocation.spec.js
@@ -1,0 +1,158 @@
+import { assert, test } from './test.js'
+import { Delegation, UCAN, invoke } from '../src/lib.js'
+import { alice, bob, mallory, service as w3 } from './fixtures.js'
+
+test('encode invocation', async () => {
+  const add = invoke({
+    issuer: alice,
+    audience: w3,
+    capability: {
+      can: 'store/add',
+      with: alice.did(),
+      link: 'bafy...stuff',
+    },
+    proofs: [],
+  })
+
+  const delegation = await add.delegate()
+
+  assert.containSubset(delegation, {
+    capabilities: [
+      {
+        can: 'store/add',
+        with: alice.did(),
+        link: 'bafy...stuff',
+      },
+    ],
+    proofs: [],
+  })
+
+  assert.deepEqual(delegation.issuer.did(), alice.did())
+  assert.deepEqual(delegation.audience.did(), w3.did())
+})
+
+test('expired invocation', async () => {
+  const expiration = UCAN.now() - 5
+  const invocation = invoke({
+    issuer: alice,
+    audience: w3.authority,
+    capability: {
+      can: 'store/add',
+      with: alice.did(),
+    },
+
+    expiration,
+  })
+
+  assert.containSubset(await invocation.delegate(), {
+    capabilities: [
+      {
+        can: 'store/add',
+        with: alice.did(),
+      },
+    ],
+    expiration,
+  })
+})
+
+test('invocation with notBefore', async () => {
+  const notBefore = UCAN.now() + 500
+  const invocation = invoke({
+    issuer: alice,
+    audience: w3.authority,
+    capability: {
+      can: 'store/add',
+      with: alice.did(),
+    },
+    notBefore,
+  })
+
+  assert.containSubset(await invocation.delegate(), {
+    capabilities: [
+      {
+        can: 'store/add',
+        with: alice.did(),
+      },
+    ],
+    notBefore,
+  })
+})
+
+test('invocation with nonce', async () => {
+  const invocation = invoke({
+    issuer: alice,
+    audience: w3.authority,
+    capability: {
+      can: 'store/add',
+      with: alice.did(),
+    },
+    nonce: 'hello',
+  })
+
+  assert.containSubset(await invocation.delegate(), {
+    capabilities: [
+      {
+        can: 'store/add',
+        with: alice.did(),
+      },
+    ],
+    nonce: 'hello',
+  })
+})
+
+test('invocation with facts', async () => {
+  const invocation = invoke({
+    issuer: alice,
+    audience: w3.authority,
+    capability: {
+      can: 'store/add',
+      with: alice.did(),
+    },
+    facts: [
+      {
+        hello: 'world',
+      },
+    ],
+  })
+
+  assert.containSubset(await invocation.delegate(), {
+    capabilities: [
+      {
+        can: 'store/add',
+        with: alice.did(),
+      },
+    ],
+    facts: [
+      {
+        hello: 'world',
+      },
+    ],
+  })
+})
+
+test('execute invocation', async () => {
+  const add = invoke({
+    issuer: alice,
+    audience: w3,
+    capability: {
+      can: 'store/add',
+      with: alice.did(),
+      link: 'bafy...stuff',
+    },
+    proofs: [],
+  })
+
+  const result = await add.execute({
+    /**
+     * @param {any} invocation
+     * @returns {Promise<any>}
+     */
+    // @ts-expect-error
+    async execute(invocation) {
+      assert.deepEqual(invocation, add)
+      return [{ hello: 'world' }]
+    },
+  })
+
+  assert.deepEqual(result, { hello: 'world' })
+})

--- a/packages/interface/src/lib.ts
+++ b/packages/interface/src/lib.ts
@@ -82,13 +82,8 @@ export type Proof<
   C extends [Capability, ...Capability[]] = [Capability, ...Capability[]]
 > = LinkedProof<C[number]> | Delegation<C>
 
-export interface DelegationOptions<
-  C extends [Capability, ...Capability[]],
-  A extends number = number
-> {
-  issuer: SigningAuthority<A>
+export interface UCANOptions {
   audience: Identity
-  capabilities: C
   lifetimeInSeconds?: number
   expiration?: number
   notBefore?: number
@@ -97,6 +92,15 @@ export interface DelegationOptions<
 
   facts?: Fact[]
   proofs?: Proof[]
+}
+
+export interface DelegationOptions<
+  C extends [Capability, ...Capability[]],
+  A extends number = number
+> extends UCANOptions {
+  issuer: SigningAuthority<A>
+  audience: Identity
+  capabilities: C
 }
 
 export interface Delegation<
@@ -128,11 +132,10 @@ export interface Delegation<
 export interface Invocation<C extends Capability = Capability>
   extends Delegation<[C]> {}
 
-export interface InvocationOptions<C extends Capability = Capability> {
+export interface InvocationOptions<C extends Capability = Capability>
+  extends UCANOptions {
   issuer: SigningAuthority
-  audience: Audience
   capability: C
-  proofs?: Proof[]
 }
 
 export interface IssuedInvocation<C extends Capability = Capability>
@@ -230,8 +233,9 @@ export type InferServiceInvocations<I extends unknown[], T> = I extends []
 
 export interface IssuedInvocationView<C extends Capability = Capability>
   extends IssuedInvocation<C> {
+  delegate(): Promise<Delegation<[C]>>
   execute<T extends InvocationService<C>>(
-    service: Connection<T>
+    service: ConnectionView<T>
   ): Await<InferServiceInvocationReturn<C, T>>
 }
 

--- a/packages/interface/src/query.ts
+++ b/packages/interface/src/query.ts
@@ -7,6 +7,7 @@ import type {
   UCAN,
   Result,
   Connection,
+  ConnectionView,
   Service,
   Authority,
   SigningAuthority,
@@ -133,7 +134,7 @@ type Store = {
   remove: StoreRemove
 }
 declare var store: Store
-declare var channel: Connection<{ store: Store }>
+declare var channel: ConnectionView<{ store: Store }>
 declare const alice: SigningAuthority
 declare const bob: Authority
 declare const car: UCAN.Link
@@ -162,7 +163,7 @@ type U = Unpack<StoreAdd & StoreRemove>
 //   ],
 // })
 
-declare var host: Connection<{ store: Store }>
+declare var host: ConnectionView<{ store: Store }>
 
 const demo = async () => {
   const add = invoke({

--- a/packages/server/src/handler.js
+++ b/packages/server/src/handler.js
@@ -7,7 +7,8 @@ import { access } from '@ucanto/validator'
  * @template {API.URI} R
  * @template {unknown} U
  * @template {API.Match} Z
- * @param {API.CapabilityParser<API.Match<API.ParsedCapability<A, R, API.InferCaveats<C>>, Z>>} capability
+ * @template {API.ParsedCapability<A, R, API.InferCaveats<C>>} T
+ * @param {API.CapabilityParser<API.Match<T, Z>>} capability
  * @param {(input:API.ProviderContext<A, R, C>) => API.Await<U>} handler
  * @returns {API.ServiceMethod<API.Capability<A, R['href']> & API.InferCaveats<C>, Exclude<U, {error:true}>, Exclude<U, Exclude<U, {error:true}>>>}
  */
@@ -15,7 +16,7 @@ import { access } from '@ucanto/validator'
 export const provide =
   (capability, handler) =>
   /**
-   * @param {API.Invocation<API.Capability<A, R['href']> & API.InferCaveats<C>>} invocation
+   * @param {API.Invocation<API.Capability<T['can'], T['with']> & T['caveats']>} invocation
    * @param {API.InvocationContext} options
    * @return {Promise<API.Result<Exclude<U, {error:true}>, Exclude<U, Exclude<U, {error:true}>>|API.InvocationError>>}
    */

--- a/packages/server/src/lib.js
+++ b/packages/server/src/lib.js
@@ -1,6 +1,7 @@
 export * from './server.js'
 export * from '@ucanto/authority'
 export * from '@ucanto/core'
+export { invoke } from '@ucanto/core'
 // @ts-ignore
 export * from './api.js'
 export * from './handler.js'

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/web3-storage/ucanto",
   "scripts": {
     "test:web": "playwright-test test/**/*.spec.js --cov && nyc report",
-    "test:node": "c8 --check-coverage --branches 90 --functions 80 --lines 90 mocha test/**/*.spec.js",
+    "test:node": "c8 --check-coverage --branches 97 --functions 85 --lines 93 mocha test/**/*.spec.js",
     "test": "npm run test:node",
     "coverage": "c8 --reporter=html mocha test/**/*.spec.js && npm_config_yes=true npx st -d coverage -p 8080",
     "typecheck": "tsc --build"

--- a/packages/validator/src/decoder/uri.js
+++ b/packages/validator/src/decoder/uri.js
@@ -8,6 +8,10 @@ import { Failure } from '../error.js'
  * @return {API.Result<API.URI<Protocol>, API.Failure>}
  */
 export const decode = (input, { protocol } = {}) => {
+  if (typeof input !== 'string' && !(input instanceof URL)) {
+    return new Failure(`Expected URI but got ${typeof input}`)
+  }
+
   try {
     const url = new URL(String(input))
     if (protocol != null && url.protocol !== protocol) {

--- a/packages/validator/src/error.js
+++ b/packages/validator/src/error.js
@@ -205,6 +205,15 @@ export class Expired extends Failure {
   get expiredAt() {
     return this.delegation.expiration
   }
+  toJSON() {
+    const { error, name, expiredAt, message } = this
+    return {
+      error,
+      name,
+      message,
+      expiredAt,
+    }
+  }
 }
 
 export class NotValidBefore extends Failure {

--- a/packages/validator/src/lib.js
+++ b/packages/validator/src/lib.js
@@ -133,11 +133,12 @@ const resolveSources = async ({ delegation }, config) => {
 
 /**
  * @template {API.Ability} A
- * @template {API.Caveats} C
  * @template {API.URI} R
+ * @template {API.Caveats} C
+ * @template {API.ParsedCapability<A, R, API.InferCaveats<C>>} T
  * @param {API.Invocation<API.Capability<A, R['href']> & API.InferCaveats<C>>} invocation
- * @param {API.ValidationOptions<API.ParsedCapability<A, R, API.InferCaveats<C>>>} config
- * @returns {Promise<API.Result<Authorization<API.ParsedCapability<A, R, API.InferCaveats<C>>>, API.Unauthorized>>}
+ * @param {API.ValidationOptions<T>} config
+ * @returns {Promise<API.Result<Authorization<T>, API.Unauthorized>>}
  */
 export const access = async (
   invocation,
@@ -337,7 +338,6 @@ class Unauthorized extends Failure {
 const ALL = '*'
 
 /**
- * @template {API.ParsedCapability} C
  * @param {API.Delegation} delegation
  * @param {Required<API.IssuingOptions>} options
  */

--- a/packages/validator/test/decoder.spec.js
+++ b/packages/validator/test/decoder.spec.js
@@ -18,7 +18,7 @@ import { CID } from 'multiformats'
 }
 
 {
-  /** @type {[string, `${string}:`, object][]} */
+  /** @type {[string, `${string}:`, {href?:string, message?:string}][]} */
   const dataset = [
     ['', 'did:', { message: 'Invalid URI' }],
     ['did:key:zAlice', 'did:', { href: 'did:key:zAlice' }],
@@ -40,6 +40,10 @@ import { CID } from 'multiformats'
       protocol,
     })}).decode(${JSON.stringify(input)})}}`, () => {
       assert.containSubset(URI.match({ protocol }).decode(input), expect)
+      assert.containSubset(
+        URI.string({ protocol }).decode(input),
+        expect.href || expect
+      )
     })
   }
 }

--- a/packages/validator/tsconfig.json
+++ b/packages/validator/tsconfig.json
@@ -102,6 +102,7 @@
   "references": [
     { "path": "../interface" },
     { "path": "../client" },
-    { "path": "../authority" }
+    { "path": "../authority" },
+    { "path": "../core" }
   ]
 }


### PR DESCRIPTION
This PR adds following features:

1. `derives` is now optional in `capability({ ... })`. If not provided will use a default which:
   1. Verifies that `claimed.with` is same as `delegated.with` or that `claimed.with` is inside `delegated.with` if later ends with `*`.
   2. Verifies that all the `delegated.caveats` are same on `claimed.caveats`.

    In many instances you'd need to define custom `derives`, but I think sane default is probably a good idea.
2. Capabilities defined with `capability()` now have `.create({ with: resource, caveats: { ... } })` function  which:
     1. Will create capability object with desired `can` field.
     2. Will pass inputs through decoders to avoid creating ones that will fail to parse on the other end.
     3. Will throw error if parameters are invalid.
3. Capabilities defined with `capability()` now have `.invoke({ ... })` function which is just like `.create` above, except it also takes `issuer`, `audience` and rest of the invocation specific options and returns `IssuedInvocation`
   - It is just a sugar around `invoke({ issuer, audience,  capability: myCap.create(...), ... })`
   - It is meant to make definitions like this obsolete
      https://github.com/web3-storage/ucanto/blob/4fed8db1e55f2fef174cb3abe09ccec897375eb5/w3/store/src/store/invoke.js#L4-L69
      https://github.com/web3-storage/ucanto/blob/4fed8db1e55f2fef174cb3abe09ccec897375eb5/w3/store/src/identity/invoke.js#L5-L83

4. `IssuedInvocation` now has `delegate()` method hopefully this sugar makes it less confusing `delegate(invocation))`
5. `invoke` previously ignored things like `expration` etc... which is fixed now.