### PR TITLE
upstream changes from w3 branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,9 +97,9 @@ jobs:
           command: pr
           upstream_owner: ${{ github.repository_owner }}
           upstream_repo: ${{ github.event.repository.name }}
-          description: 'release master'
-          title: 'chore: release master'
-          message: 'chore: release master'
+          description: '🚢 release ucanto'
+          title: 'chore: release ucanto'
+          message: 'chore: release ucanto'
           branch: release-please/branches/main
           primary: main
           force: true

--- a/packages/client/src/connection.js
+++ b/packages/client/src/connection.js
@@ -19,6 +19,7 @@ class Connection {
    * @param {API.ConnectionOptions<T>} options
    */
   constructor(options) {
+    this.id = options.id
     this.options = options
     this.encoder = options.encoder
     this.decoder = options.decoder

--- a/packages/client/test/client.spec.js
+++ b/packages/client/test/client.spec.js
@@ -4,12 +4,13 @@ import * as HTTP from '@ucanto/transport/http'
 import * as CAR from '@ucanto/transport/car'
 import * as CBOR from '@ucanto/transport/cbor'
 import * as Service from './service.js'
-import { alice, bob, mallory, service as web3Storage } from './fixtures.js'
+import { alice, bob, mallory, service as w3 } from './fixtures.js'
 import fetch from '@web-std/fetch'
 
 test('encode inovocation', async () => {
   /** @type {Client.ConnectionView<Service.Service>} */
   const connection = Client.connect({
+    id: w3.authority,
     channel: HTTP.open({ url: new URL('about:blank'), fetch }),
     encoder: CAR,
     decoder: CBOR,
@@ -21,7 +22,7 @@ test('encode inovocation', async () => {
 
   const add = Client.invoke({
     issuer: alice,
-    audience: web3Storage,
+    audience: w3,
     capability: {
       can: 'store/add',
       with: alice.did(),
@@ -42,7 +43,7 @@ test('encode inovocation', async () => {
   const [invocation] = request
   assert.equal(request.length, 1)
   assert.equal(invocation.issuer.did(), alice.did())
-  assert.equal(invocation.audience.did(), web3Storage.did())
+  assert.equal(invocation.audience.did(), w3.did())
   assert.deepEqual(invocation.proofs, [])
   assert.deepEqual(invocation.capabilities, [
     {
@@ -61,6 +62,7 @@ test('encode delegated invocation', async () => {
 
   /** @type {Client.ConnectionView<Service.Service>} */
   const connection = Client.connect({
+    id: w3.authority,
     channel: HTTP.open({ url: new URL('about:blank'), fetch }),
     encoder: CAR,
     decoder: CBOR,
@@ -79,7 +81,7 @@ test('encode delegated invocation', async () => {
 
   const add = Client.invoke({
     issuer: bob,
-    audience: web3Storage,
+    audience: w3,
     capability: {
       can: 'store/add',
       with: alice.did(),
@@ -90,7 +92,7 @@ test('encode delegated invocation', async () => {
 
   const remove = Client.invoke({
     issuer: alice,
-    audience: web3Storage,
+    audience: w3,
     capability: {
       can: 'store/remove',
       with: alice.did(),
@@ -105,7 +107,7 @@ test('encode delegated invocation', async () => {
     assert.equal(request.length, 2)
 
     assert.equal(add.issuer.did(), bob.did())
-    assert.equal(add.audience.did(), web3Storage.did())
+    assert.equal(add.audience.did(), w3.did())
     assert.deepEqual(add.capabilities, [
       {
         can: 'store/add',
@@ -123,7 +125,7 @@ test('encode delegated invocation', async () => {
     assert.deepEqual(delegation.capabilities, proof.capabilities)
 
     assert.equal(remove.issuer.did(), alice.did())
-    assert.equal(remove.audience.did(), web3Storage.did())
+    assert.equal(remove.audience.did(), w3.did())
     assert.deepEqual(remove.proofs, [])
     assert.deepEqual(remove.capabilities, [
       {
@@ -138,6 +140,7 @@ test('encode delegated invocation', async () => {
 const service = Service.create()
 /** @type {Client.ConnectionView<Service.Service>} */
 const connection = Client.connect({
+  id: w3.authority,
   channel: HTTP.open({
     url: new URL('about:blank'),
     fetch: async (url, input) => {
@@ -180,7 +183,7 @@ test('execute', async () => {
 
   const add = Client.invoke({
     issuer: alice,
-    audience: web3Storage,
+    audience: w3,
     capability: {
       can: 'store/add',
       with: alice.did(),
@@ -191,7 +194,7 @@ test('execute', async () => {
 
   const remove = Client.invoke({
     issuer: alice,
-    audience: web3Storage,
+    audience: w3,
     capability: {
       can: 'store/remove',
       with: alice.did(),

--- a/packages/interface/src/lib.ts
+++ b/packages/interface/src/lib.ts
@@ -292,21 +292,24 @@ export interface HandlerExecutionError extends Failure {
 
 export type API<T> = T[keyof T]
 
-export interface ConnectionOptions<T> extends Transport.EncodeOptions {
+export interface OutpboundTranpsortOptions {
   readonly encoder: Transport.RequestEncoder
   readonly decoder: Transport.ResponseDecoder
+}
+export interface ConnectionOptions<T>
+  extends Transport.EncodeOptions,
+    OutpboundTranpsortOptions {
+  readonly id: Identity
   readonly channel: Transport.Channel<T>
 }
 
-export interface Connection<T> extends Phantom<T> {
-  readonly encoder: Transport.RequestEncoder
-  readonly decoder: Transport.ResponseDecoder
-  readonly channel: Transport.Channel<T>
-
+export interface Connection<T> extends Phantom<T>, ConnectionOptions<T> {
+  readonly id: Identity
   readonly hasher: MultihashHasher
 }
 
 export interface ConnectionView<T> extends Connection<T> {
+  id: Identity
   execute<
     C extends Capability,
     I extends Transport.Tuple<ServiceInvocation<C, T>>
@@ -315,7 +318,7 @@ export interface ConnectionView<T> extends Connection<T> {
   ): Await<InferServiceInvocations<I, T>>
 }
 
-export interface TranpsortOptions {
+export interface InboundTransportOptions {
   /**
    * Request decoder which is will be used by a server to decode HTTP Request
    * into an invocation `Batch` that will be executed using a `service`.
@@ -341,7 +344,9 @@ export interface ValidatorOptions {
   readonly resolve?: InvocationContext['resolve']
 }
 
-export interface ServerOptions extends TranpsortOptions, ValidatorOptions {
+export interface ServerOptions
+  extends InboundTransportOptions,
+    ValidatorOptions {
   /**
    * Service DID which will be used to verify that received invocation
    * audience matches it.

--- a/packages/server/test/handler.spec.js
+++ b/packages/server/test/handler.spec.js
@@ -109,6 +109,7 @@ test('checks service id', async () => {
   })
 
   const client = Client.connect({
+    id: w3.authority,
     encoder: CAR,
     decoder: CBOR,
     channel: server,

--- a/packages/server/test/server.spec.js
+++ b/packages/server/test/server.spec.js
@@ -72,6 +72,7 @@ test('encode delegated invocation', async () => {
   })
 
   const connection = Client.connect({
+    id: w3.authority,
     encoder: CAR,
     decoder: CBOR,
     channel: server,
@@ -166,6 +167,7 @@ test('unknown handler', async () => {
   })
 
   const connection = Client.connect({
+    id: w3.authority,
     encoder: CAR,
     decoder: CBOR,
     channel: server,
@@ -233,6 +235,7 @@ test('execution error', async () => {
   })
 
   const connection = Client.connect({
+    id: w3.authority,
     encoder: CAR,
     decoder: CBOR,
     channel: server,

--- a/packages/transport/src/car/codec.js
+++ b/packages/transport/src/car/codec.js
@@ -109,15 +109,20 @@ export const decode = async (bytes) => {
 }
 
 /**
+ * @param {Uint8Array} bytes
+ * @param {{hasher?: API.MultihashHasher }} [options]
+ */
+export const link = async (bytes, { hasher = sha256 } = {}) =>
+  /** @type {UCAN.Link<Model, typeof code, number> & import('multiformats').CID} */
+  (createLink(code, await hasher.digest(bytes)))
+
+/**
  * @param {Partial<Model>} data
  * @param {{hasher?: API.MultihashHasher }} [options]
  */
 export const write = async (data, { hasher = sha256 } = {}) => {
   const bytes = encode(data)
-  const digest = await hasher.digest(bytes)
+  const cid = await link(bytes)
 
-  const cid =
-    /** @type {UCAN.Link<Model, typeof code, number> & import('multiformats').CID}*/
-    (createLink(code, digest))
   return { bytes, cid }
 }

--- a/packages/transport/test/car.spec.js
+++ b/packages/transport/test/car.spec.js
@@ -243,6 +243,9 @@ test('codec', async () => {
   const car = await CAR.codec.write({ roots: [root] })
   assert.deepEqual(car.bytes, bytes)
   assert.ok(asLink(car.cid) === car.cid)
+
+  const link = await CAR.codec.link(car.bytes)
+  assert.deepEqual(car.cid, link)
 })
 
 test('car writer', async () => {


### PR DESCRIPTION
- client now needs DID of the service (you really need both everywhere and it makes sense to just stick one there)
- car encoder now exports `link` function for case where you just want to generate CAR cid from car bytes. 