### PR TITLE
W3 signer token

### DIFF
--- a/.github/workflows/interface.yml
+++ b/.github/workflows/interface.yml
@@ -58,7 +58,7 @@ jobs:
           - windows-latest
           - macos-latest
         project:
-          - core
+          - interface
 
     steps:
       - uses: actions/checkout@v2

--- a/w3/sigv4/src/index.js
+++ b/w3/sigv4/src/index.js
@@ -6,7 +6,7 @@ export class SigV4 {
   /**
    * @param {import('./types').SigV4Options} options
    */
-  constructor({ accessKeyId, secretAccessKey, region, cache, securityToken }) {
+  constructor({ accessKeyId, secretAccessKey, region, cache, sessionToken }) {
     this.accessKeyId = accessKeyId
     this.secretAccessKey = secretAccessKey
     /** @type {string} */
@@ -21,7 +21,7 @@ export class SigV4 {
       this.service,
       'aws4_request',
     ].join('/')
-    this.securityToken = securityToken
+    this.sessionToken = sessionToken
   }
 
   /**
@@ -56,8 +56,8 @@ export class SigV4 {
       this.accessKeyId + '/' + this.credentialString
     )
     params.set('X-Amz-SignedHeaders', this.signedHeaders)
-    if (this.securityToken) {
-      params.set('x-amz-security-token', this.securityToken)
+    if (this.sessionToken) {
+      params.set('x-amz-security-token', this.sessionToken)
     }
 
     // Encode query string to be signed

--- a/w3/sigv4/src/index.js
+++ b/w3/sigv4/src/index.js
@@ -57,7 +57,7 @@ export class SigV4 {
     )
     params.set('X-Amz-SignedHeaders', this.signedHeaders)
     if (this.sessionToken) {
-      params.set('x-amz-security-token', this.sessionToken)
+      params.set('X-Amz-Security-Token', this.sessionToken)
     }
 
     // Encode query string to be signed

--- a/w3/sigv4/src/index.js
+++ b/w3/sigv4/src/index.js
@@ -6,7 +6,7 @@ export class SigV4 {
   /**
    * @param {import('./types').SigV4Options} options
    */
-  constructor({ accessKeyId, secretAccessKey, region, cache }) {
+  constructor({ accessKeyId, secretAccessKey, region, cache, securityToken }) {
     this.accessKeyId = accessKeyId
     this.secretAccessKey = secretAccessKey
     /** @type {string} */
@@ -21,6 +21,7 @@ export class SigV4 {
       this.service,
       'aws4_request',
     ].join('/')
+    this.securityToken = securityToken
   }
 
   /**
@@ -55,6 +56,9 @@ export class SigV4 {
       this.accessKeyId + '/' + this.credentialString
     )
     params.set('X-Amz-SignedHeaders', this.signedHeaders)
+    if (this.securityToken) {
+      params.set('x-amz-security-token', this.signedHeaders)
+    }
 
     // Encode query string to be signed
     const seenKeys = new Set()

--- a/w3/sigv4/src/index.js
+++ b/w3/sigv4/src/index.js
@@ -57,7 +57,7 @@ export class SigV4 {
     )
     params.set('X-Amz-SignedHeaders', this.signedHeaders)
     if (this.securityToken) {
-      params.set('x-amz-security-token', this.signedHeaders)
+      params.set('x-amz-security-token', this.securityToken)
     }
 
     // Encode query string to be signed

--- a/w3/sigv4/src/types.ts
+++ b/w3/sigv4/src/types.ts
@@ -1,7 +1,7 @@
 export interface SigV4Options {
   accessKeyId: string
   secretAccessKey: string
-  securityToken?: string
+  sessionToken?: string
   region: string
   cache?: Map<string, ArrayBuffer>
 }

--- a/w3/sigv4/src/types.ts
+++ b/w3/sigv4/src/types.ts
@@ -1,6 +1,7 @@
 export interface SigV4Options {
   accessKeyId: string
   secretAccessKey: string
+  securityToken?: string
   region: string
   cache?: Map<string, ArrayBuffer>
 }

--- a/w3/store/src/signer/lib.js
+++ b/w3/store/src/signer/lib.js
@@ -13,6 +13,7 @@ export const sign = (link, { bucket, expires = 1000, ...options }) => {
     accessKeyId: options.accessKeyId,
     secretAccessKey: options.secretAccessKey,
     region: options.region,
+    securityToken: options.securityToken,
   })
 
   const checksum = base64pad.baseEncode(link.multihash.digest)

--- a/w3/store/src/signer/lib.js
+++ b/w3/store/src/signer/lib.js
@@ -13,7 +13,7 @@ export const sign = (link, { bucket, expires = 1000, ...options }) => {
     accessKeyId: options.accessKeyId,
     secretAccessKey: options.secretAccessKey,
     region: options.region,
-    securityToken: options.securityToken,
+    sessionToken: options.sessionToken,
   })
 
   const checksum = base64pad.baseEncode(link.multihash.digest)

--- a/w3/store/src/signer/type.ts
+++ b/w3/store/src/signer/type.ts
@@ -3,6 +3,7 @@ export type { Link } from '@ucanto/interface'
 export interface SignOptions {
   accessKeyId: string
   secretAccessKey: string
+  securityToken?: string
   region: string
   bucket: string
   expires?: number

--- a/w3/store/src/signer/type.ts
+++ b/w3/store/src/signer/type.ts
@@ -3,7 +3,7 @@ export type { Link } from '@ucanto/interface'
 export interface SignOptions {
   accessKeyId: string
   secretAccessKey: string
-  securityToken?: string
+  sessionToken?: string
   region: string
   bucket: string
   expires?: number


### PR DESCRIPTION
Extends options for the signer service and the SIGV4 to allow passing the security token generated when a temp IAM is used instead of a user based one.