### PR TITLE
fix: make paths work on every platform

### DIFF
--- a/w3/cli/src/main.js
+++ b/w3/cli/src/main.js
@@ -16,6 +16,7 @@ import * as Service from 'w3-store'
 import * as CAR from '@ucanto/transport/car'
 import * as FS from 'node:fs/promises'
 import fetch from '@web-std/fetch'
+import path from 'path'
 
 const cli = Soly.createCLI('w3-cli')
 cli
@@ -361,10 +362,9 @@ const connect = ({
 
 /**
  *
- * @param {string} path
+ * @param {string} relativeFilepath
  */
 
-const resolveURL = (path) =>
-  new URL(path, new URL(`${process.cwd()}`, import.meta.url).href + '/')
+const resolveURL = (relativeFilepath) => path.resolve(`${process.cwd()}`, relativeFilepath)
 
 script({ ...import.meta, main, dotenv: true })


### PR DESCRIPTION
This will break on some operating systems that will not be named so their feelings don't get hurt. the `path` module smooths out inconsistencies like slash direction.