### PR TITLE
fix: use chai assert

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -303,10 +303,12 @@ importers:
   w3/sigv4:
     specifiers:
       '@noble/hashes': ^1.0.0
+      '@types/chai': ^4.3.1
       '@types/mocha': ^9.1.0
       '@types/node': ^17.0.23
       '@web-std/fetch': ^4.0.0
       assert: ^2.0.0
+      chai: ^4.3.6
       delay: ^5.0.0
       dotenv: ^16.0.0
       mocha: ^9.2.2
@@ -315,10 +317,12 @@ importers:
     dependencies:
       '@noble/hashes': 1.1.1
     devDependencies:
+      '@types/chai': 4.3.1
       '@types/mocha': 9.1.1
       '@types/node': 17.0.41
       '@web-std/fetch': 4.1.0
       assert: 2.0.0
+      chai: 4.3.6
       delay: 5.0.0
       dotenv: 16.0.1
       mocha: 9.2.2

--- a/w3/sigv4/package.json
+++ b/w3/sigv4/package.json
@@ -29,12 +29,14 @@
   },
   "devDependencies": {
     "@types/mocha": "^9.1.0",
+    "@types/chai": "^4.3.1",
     "@types/node": "^17.0.23",
     "@web-std/fetch": "^4.0.0",
     "assert": "^2.0.0",
     "delay": "^5.0.0",
     "dotenv": "^16.0.0",
     "mocha": "^9.2.2",
+    "chai": "^4.3.6",
     "playwright-test": "^7.3.0",
     "watch": "^1.0.2"
   },

--- a/w3/sigv4/test/sigv4.test.js
+++ b/w3/sigv4/test/sigv4.test.js
@@ -1,4 +1,4 @@
-import assert from 'assert'
+import { assert } from 'chai'
 import { sha256 } from '@noble/hashes/sha256'
 import { SigV4 } from '../src/index.js'
 import fetch from '@web-std/fetch'


### PR DESCRIPTION
Addresses failures observed in https://github.com/web3-storage/ucanto/pull/62

I believe whatever "assert" module was loaded in chrome did not have assert.match function which caused test fail.