### PR TITLE
Fix/cross platform urls

### DIFF
--- a/w3/cli/src/main.js
+++ b/w3/cli/src/main.js
@@ -17,6 +17,7 @@ import * as CAR from '@ucanto/transport/car'
 import * as FS from 'node:fs/promises'
 import fetch from '@web-std/fetch'
 import path from 'path'
+import { pathToFileURL } from 'url'
 
 const cli = Soly.createCLI('w3-cli')
 cli
@@ -350,8 +351,8 @@ const configure = ({ projectName = 'w3-cli' } = {}) => {
  * @param {string} relativeFilepath
  */
 
-const resolveURL = (relativeFilepath) => path.resolve(process.cwd(), relativeFilepath)
-
+const resolveURL = (relativeFilepath) =>
+  pathToFileURL(path.resolve(process.cwd(), relativeFilepath))
 
 /**
  * @param {{id?: Client.DID, url?:URL}} [config]

--- a/w3/cli/src/main.js
+++ b/w3/cli/src/main.js
@@ -349,8 +349,8 @@ const configure = ({ projectName = 'w3-cli' } = {}) => {
 /**
  *
  * @param {string} relativeFilepath
+ * @returns {URL}
  */
-
 const resolveURL = (relativeFilepath) =>
   pathToFileURL(path.resolve(process.cwd(), relativeFilepath))
 

--- a/w3/cli/src/main.js
+++ b/w3/cli/src/main.js
@@ -347,6 +347,14 @@ const configure = ({ projectName = 'w3-cli' } = {}) => {
 }
 
 /**
+ *
+ * @param {string} relativeFilepath
+ */
+
+const resolveURL = (relativeFilepath) => path.resolve(process.cwd(), relativeFilepath)
+
+
+/**
  * @param {{id?: Client.DID, url?:URL}} [config]
  */
 const connect = ({
@@ -361,12 +369,6 @@ const connect = ({
     url,
   })
 
-/**
- *
- * @param {string} relativeFilepath
- */
 
-const resolveURL = (relativeFilepath) =>
-  pathToFileURL(path.resolve(process.cwd(), relativeFilepath))
 
 script({ ...import.meta, main, dotenv: true })

--- a/w3/cli/src/main.js
+++ b/w3/cli/src/main.js
@@ -17,7 +17,6 @@ import * as CAR from '@ucanto/transport/car'
 import * as FS from 'node:fs/promises'
 import fetch from '@web-std/fetch'
 import path from 'path'
-import { pathToFileURL } from 'url'
 
 const cli = Soly.createCLI('w3-cli')
 cli


### PR DESCRIPTION
Not sure why, there was still a lingering issue with this url resolver for me, but this fixes it.
The main change is removing "pathToFileURL" which produced the error:
```sh
TypeError [ERR_INVALID_URL]: Invalid URL
    at new NodeError (node:internal/errors:371:5)
    at onParseError (node:internal/url:552:9)
    at parse (<anonymous>)
    at new URL (node:internal/url:628:5)
``` 
~~path.resolve by itself seems to work ok~~

It needs to be a URL type for your typing