### PR TITLE
Pass service DID to accounting

### DIFF
--- a/w3/store/src/accounting/lib.js
+++ b/w3/store/src/accounting/lib.js
@@ -1,25 +1,27 @@
 import * as API from '../type.js'
 
 /**
+ * @typdef {[service:DID, group:DID, car:DID, proof:API.Accounting.Link, ]} Table
  * @typedef {{has(path:string): API.Await<boolean>}} FileStore
  * @typedef {Map<string, API.Accounting.Link|null>} CARSet
  * @typedef {{
- * set(id:API.DID, value:CARSet):API.Await<unknown>
- * get(id:API.DID): API.Await<CARSet|undefined>
+ * set(id:string, value:CARSet):API.Await<unknown>
+ * get(id:string): API.Await<CARSet|undefined>
  * }} MetadataStore
  * @param {{db?:MetadataStore, cars?:FileStore}} [options]
  * @returns {API.Accounting.Provider}
  */
 export const create = ({ db = new Map(), cars = new Map() } = {}) => ({
   /**
+   * @param {API.DID} service
    * @param {API.DID} group
    * @param {API.Accounting.Link} link
    * @param {API.LinkedProof} proof
    */
-  async add(group, link, proof) {
+  async add(service, group, link, proof) {
     const [members, have] = await Promise.all([
-      db.get(group),
-      cars.has(`${link}/data`),
+      db.get(`${group}@${service}`),
+      cars.has(`${link}/${link}.car`),
     ])
 
     if (members) {
@@ -32,23 +34,25 @@ export const create = ({ db = new Map(), cars = new Map() } = {}) => ({
     return have ? { status: 'in-s3' } : { status: 'not-in-s3' }
   },
   /**
+   * @param {API.DID} service
    * @param {API.DID} group
    * @param {API.Accounting.Link} link
    * @param {API.LinkedProof} proof
    */
-  async remove(group, link, proof) {
-    const members = await db.get(group)
+  async remove(service, group, link, proof) {
+    const members = await db.get(`${group}@${service}`)
     if (members) {
       members.set(`${link}`, null)
     }
     return null
   },
   /**
+   * @param {API.DID} service
    * @param {API.DID} group
    * @param {API.LinkedProof} proof
    */
-  async list(group, proof) {
-    const members = await db.get(group)
+  async list(service, group, proof) {
+    const members = await db.get(`${group}@${service}`)
     const links = []
     for (const member of members?.values() || []) {
       if (member) {

--- a/w3/store/src/store/provider.js
+++ b/w3/store/src/store/provider.js
@@ -36,7 +36,12 @@ export const create = ({ id, identity, accounting, signingOptions }) => ({
         return account
       }
 
-      const result = await accounting.add(group, link, invocation.cid)
+      const result = await accounting.add(
+        invocation.audience.did(),
+        group,
+        link,
+        invocation.cid
+      )
       if (result.error) {
         return result
       }
@@ -68,12 +73,21 @@ export const create = ({ id, identity, accounting, signingOptions }) => ({
       }
 
       const group = /** @type {API.DID} */ (capability.with)
-      await accounting.remove(group, link, invocation.cid)
+      await accounting.remove(
+        invocation.audience.did(),
+        group,
+        link,
+        invocation.cid
+      )
       return link
     }),
     list: provide(Capability.List, async ({ capability, invocation }) => {
       const group = /** @type {API.DID} */ (capability.with)
-      return await accounting.list(group, invocation.cid)
+      return await accounting.list(
+        invocation.audience.did(),
+        group,
+        invocation.cid
+      )
     }),
   },
   // this is a boilerplate that redelegates all the `identity/*` capabilities

--- a/w3/store/src/type/accounting.ts
+++ b/w3/store/src/type/accounting.ts
@@ -1,10 +1,10 @@
-import { DID, LinkedProof, Result, Await } from "@ucanto/interface"
-import * as API from "@ucanto/interface"
-import { ServiceError } from "./error"
+import { DID, LinkedProof, Result, Await } from '@ucanto/interface'
+import * as API from '@ucanto/interface'
+import { ServiceError } from './error'
 export type Error = QuotaViolationError
 
 export interface QuotaViolationError
-  extends ServiceError<"QuotaViolationError", QuotaViolationError> {}
+  extends ServiceError<'QuotaViolationError', QuotaViolationError> {}
 
 export interface Link<
   T extends unknown = unknown,
@@ -19,21 +19,32 @@ export interface Provider {
    * `group` is associated with some account. Provider will record link to
    * group association for the future accounting.
    *
+   * @param service
    * @param group
    * @param link
    * @param proof
    */
   add(
+    service: DID,
     group: DID,
     link: Link,
     proof: LinkedProof
   ): Await<Result<LinkState, Error>>
 
-  remove(group: DID, link: Link, proof: LinkedProof): Await<Result<null, never>>
+  remove(
+    service: DID,
+    group: DID,
+    link: Link,
+    proof: LinkedProof
+  ): Await<Result<null, never>>
 
-  list(group: DID, proof: LinkedProof): Await<Result<Link[], never>>
+  list(
+    service: DID,
+    group: DID,
+    proof: LinkedProof
+  ): Await<Result<Link[], never>>
 }
 
 interface LinkState {
-  status: "in-s3" | "not-in-s3"
+  status: 'in-s3' | 'not-in-s3'
 }

--- a/w3/store/test/lib.spec.js
+++ b/w3/store/test/lib.spec.js
@@ -140,7 +140,7 @@ test('main', async () => {
       })
 
       // add car to S3
-      s3.set(`${car.cid}/data`, true)
+      s3.set(`${car.cid}/${car.cid}.car`, true)
 
       const result = await Store.Add.invoke({
         issuer: alice,


### PR DESCRIPTION
In our last sync call it was decided that we want to track service DID (which is either one for nft.storage or web3.storage) in our accounting. This pull request:

1. Amends `Accounting` to add additional `service` parameter to all methods.
2. Updates `store/*` service implementation so it passes invocation audience DID into `service` parameter.
3. Updates reference implementation and tests accordingly.

@ice-breaker-tg we would need to update actual `Accounting` provider implementation as well, but unlike ref implementation we probably should separate columns for `service` and `group` fields instead of combining combining them together.


@mikeal @hugomrdias tagging you here as well because right now we aren't passing `service` info into `identity/resolve` and we may want such thing if two diverge into separate entities. 