### PR TITLE
feat: only use native fetch type and Headers object

### DIFF
--- a/packages/client/src/connection.js
+++ b/packages/client/src/connection.js
@@ -8,7 +8,7 @@ import { sha256 } from 'multiformats/hashes/sha2'
  * @param {API.ConnectionOptions<T>} options
  * @returns {API.ConnectionView<T>}
  */
-export const connect = (options) => new Connection(options)
+export const connect = options => new Connection(options)
 
 /**
  * @template {Record<string, any>} T

--- a/packages/interface/src/transport.ts
+++ b/packages/interface/src/transport.ts
@@ -46,12 +46,12 @@ export interface ResponseDecoder {
 
 export interface HTTPRequest<T = unknown> extends Phantom<T> {
   method?: string
-  headers: Readonly<Record<string, string>>
+  headers: Headers
   body: Uint8Array
 }
 
 export interface HTTPResponse<T = unknown> extends Phantom<T> {
-  headers: Readonly<Record<string, string>>
+  headers: Headers
   body: Uint8Array
 }
 

--- a/packages/transport/src/car.js
+++ b/packages/transport/src/car.js
@@ -30,7 +30,7 @@ export const encode = async (invocations, options) => {
   const body = CAR.encode({ roots, blocks })
 
   return {
-    headers: HEADERS,
+    headers: new Headers(HEADERS),
     body,
   }
 }
@@ -43,7 +43,7 @@ export const encode = async (invocations, options) => {
  * @returns {Promise<API.InferInvocations<Invocations>>}
  */
 export const decode = async ({ headers, body }) => {
-  const contentType = headers['content-type'] || headers['Content-Type']
+  const contentType = headers.get('content-type')
   if (contentType !== 'application/car') {
     throw TypeError(
       `Only 'content-type: application/car' is supported, instead got '${contentType}'`

--- a/packages/transport/src/cbor.js
+++ b/packages/transport/src/cbor.js
@@ -14,9 +14,9 @@ export const codec = CBOR
  * @param {I} result
  * @returns {API.HTTPResponse<I>}
  */
-export const encode = (result) => {
+export const encode = result => {
   return {
-    headers: HEADERS,
+    headers: new Headers(HEADERS),
     body: CBOR.encode(result),
   }
 }
@@ -29,10 +29,10 @@ export const encode = (result) => {
  * @returns {Promise<I>}
  */
 export const decode = async ({ headers, body }) => {
-  const contentType = headers['content-type'] || headers['Content-Type']
+  const contentType = headers.get('content-type')
   if (contentType !== 'application/cbor') {
     throw TypeError(
-      `Only 'content-type: application/cbor' is supported, intsead got '${contentType}'`
+      `Only 'content-type: application/cbor' is supported, instead got '${contentType}'`
     )
   }
 

--- a/packages/transport/src/http.js
+++ b/packages/transport/src/http.js
@@ -1,23 +1,12 @@
 import * as API from '@ucanto/interface'
-
 /**
- * @typedef {{
- * ok: boolean
- * arrayBuffer():API.Await<ArrayBuffer>
- * headers: {
- *  entries():Iterable<[string, string]>
- * }
- * status?: number
- * statusText?: string
- * url?: string
- * }} FetchResponse
- * @typedef {(url:string, init:API.HTTPRequest<API.Tuple<API.ServiceInvocation>>) => API.Await<FetchResponse>} Fetcher
+ * @typedef {typeof fetch} Fetcher
  */
 /**
  * @template T
  * @param {object} options
  * @param {URL} options.url
- * @param {(url:string, init:API.HTTPRequest<API.Tuple<API.ServiceInvocation>>) => API.Await<FetchResponse>} [options.fetch]
+ * @param {Fetcher} [options.fetch]
  * @param {string} [options.method]
  * @returns {API.Channel<T>}
  */
@@ -62,7 +51,7 @@ class Channel {
       : HTTPError.throw('HTTP Request failed', response)
 
     return {
-      headers: Object.fromEntries(response.headers.entries()),
+      headers: response.headers,
       body: new Uint8Array(buffer),
     }
   }

--- a/packages/transport/src/jwt.js
+++ b/packages/transport/src/jwt.js
@@ -31,7 +31,7 @@ export const encode = async batch => {
   }
 
   return {
-    headers,
+    headers: new Headers(headers),
     body: UTF8.encode(JSON.stringify(body)),
   }
 }
@@ -57,7 +57,7 @@ const iterate = function* (delegation) {
  * @returns {Promise<API.InferInvocations<I>>}
  */
 export const decode = async ({ headers, body }) => {
-  const contentType = headers['content-type'] || headers['Content-Type']
+  const contentType = headers.get('content-type')
   if (contentType !== 'application/json') {
     throw TypeError(
       `Only 'content-type: application/json' is supported, instead got '${contentType}'`
@@ -66,7 +66,7 @@ export const decode = async ({ headers, body }) => {
   /** @type {API.Block[]} */
   const invocations = []
   const blocks = new Map()
-  for (const [name, value] of Object.entries(headers)) {
+  for (const [name, value] of headers.entries()) {
     if (name.startsWith(HEADER_PREFIX)) {
       const key = name.slice(HEADER_PREFIX.length)
       const data = UCAN.parse(/** @type {UCAN.JWT<any>} */ (value))

--- a/packages/transport/test/car.spec.js
+++ b/packages/transport/test/car.spec.js
@@ -29,9 +29,12 @@ test('encode / decode', async () => {
     },
   ])
 
-  assert.deepEqual(request.headers, {
-    'content-type': 'application/car',
-  })
+  assert.deepEqual(
+    request.headers,
+    new Headers({
+      'content-type': 'application/car',
+    })
+  )
   const reader = await CarReader.fromBytes(request.body)
 
   assert.deepEqual(await reader.getRoots(), [cid])
@@ -73,9 +76,9 @@ test('decode requires application/car contet type', async () => {
   try {
     await CAR.decode({
       body,
-      headers: {
+      headers: new Headers({
         'content-type': 'application/octet-stream',
-      },
+      }),
     })
     assert.fail('expected to fail')
   } catch (error) {
@@ -102,9 +105,9 @@ test('accepts Content-Type as well', async () => {
 
   const [invocation] = await CAR.decode({
     ...request,
-    headers: {
+    headers: new Headers({
       'Content-Type': 'application/car',
-    },
+    }),
   })
 
   const delegation = await delegate({

--- a/packages/transport/test/cbor.spec.js
+++ b/packages/transport/test/cbor.spec.js
@@ -7,9 +7,9 @@ test('encode / decode', async () => {
   const response = CBOR.encode([{ ok: true, value: 1 }])
 
   assert.deepEqual(response, {
-    headers: {
+    headers: new Headers({
       'content-type': 'application/cbor',
-    },
+    }),
     body: encode([{ ok: true, value: 1 }]),
   })
 
@@ -19,7 +19,7 @@ test('encode / decode', async () => {
 test('throws on wrong content-type', async () => {
   try {
     await CBOR.decode({
-      headers: { 'content-type': 'application/octet-stream' },
+      headers: new Headers({ 'content-type': 'application/octet-stream' }),
       body: encode([{ ok: true, value: 1 }]),
     })
     assert.fail('should have failed')
@@ -31,7 +31,7 @@ test('throws on wrong content-type', async () => {
 test('content-type case', async () => {
   assert.deepEqual(
     await CBOR.decode({
-      headers: { 'Content-Type': 'application/cbor' },
+      headers: new Headers({ 'Content-Type': 'application/cbor' }),
       body: encode([{ ok: true, value: 1 }]),
     }),
     [{ ok: true, value: 1 }]

--- a/packages/transport/test/https.spec.js
+++ b/packages/transport/test/https.spec.js
@@ -6,6 +6,7 @@ import { CAR, JWT, CBOR } from '../src/lib.js'
 test('encode / decode', async () => {
   const channel = HTTP.open({
     url: new URL('about:blank'),
+    // @ts-expect-error - we are mocking fetch it does not implement of the type properties
     fetch: async (url, init) => {
       assert.equal(url.toString(), 'about:blank')
       assert.equal(init?.method, 'POST')
@@ -18,14 +19,22 @@ test('encode / decode', async () => {
   })
 
   const response = await channel.request({
-    headers: { 'content-type': 'text/plain' },
+    headers: new Headers({ 'content-type': 'text/plain' }),
     body: UTF8.encode('ping'),
   })
 
-  assert.deepEqual(response, {
-    headers: { 'content-type': 'text/plain' },
-    body: UTF8.encode('pong'),
-  })
+  assert.deepEqual(
+    {
+      headers: Object.entries(response.headers.entries()),
+      body: response.body,
+    },
+    {
+      headers: Object.entries(
+        new Headers({ 'content-type': 'text/plain' }).entries()
+      ),
+      body: UTF8.encode('pong'),
+    }
+  )
 })
 
 if (!globalThis.fetch) {
@@ -40,6 +49,7 @@ if (!globalThis.fetch) {
 test('failed request', async () => {
   const channel = HTTP.open({
     url: new URL('https://ucan.xyz/'),
+    // @ts-expect-error - we are mocking fetch it does not implement of the type properties
     fetch: async (url, init) => {
       return {
         ok: false,
@@ -54,7 +64,7 @@ test('failed request', async () => {
 
   try {
     await channel.request({
-      headers: { 'content-type': 'text/plain' },
+      headers: new Headers({ 'content-type': 'text/plain' }),
       body: UTF8.encode('ping'),
     })
     assert.fail('expected to throw')


### PR DESCRIPTION
avoid ts errors when passing fetch implementation and normally we only have Headers object in all the env so no need to deal we other types 