### PR TITLE
fix: optional field validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "pnpm": {
     "overrides": {
-      "multiformats": "^10.0.0"
+      "multiformats": "^10.0.2"
     }
   }
 }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@ucanto/interface": "^3.0.0",
-    "multiformats": "^10.0.0"
+    "multiformats": "^10.0.2"
   },
   "devDependencies": {
     "@types/chai": "^4.3.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -33,7 +33,7 @@
     "@ipld/dag-cbor": "^8.0.0",
     "@ipld/dag-ucan": "^2.0.0",
     "@ucanto/interface": "^3.0.0",
-    "multiformats": "^10.0.0"
+    "multiformats": "^10.0.2"
   },
   "devDependencies": {
     "@types/chai": "^4.3.3",

--- a/packages/interface/package.json
+++ b/packages/interface/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@ipld/dag-ucan": "^2.0.0",
-    "multiformats": "^10.0.0"
+    "multiformats": "^10.0.2"
   },
   "devDependencies": {
     "typescript": "^4.8.4"

--- a/packages/interface/src/capability.ts
+++ b/packages/interface/src/capability.ts
@@ -299,8 +299,8 @@ export interface Descriptor<
   nb?: C
 
   derives?: Derives<
-    ParsedCapability<A, R, InferCaveats<C>>,
-    ParsedCapability<A, R, InferCaveats<C>>
+    ParsedCapability<A, R, Partial<InferCaveats<C>>>,
+    ParsedCapability<A, R, Partial<InferCaveats<C>>>
   >
 }
 

--- a/packages/principal/package.json
+++ b/packages/principal/package.json
@@ -30,7 +30,7 @@
     "@ipld/dag-ucan": "^2.0.0",
     "@noble/ed25519": "^1.7.1",
     "@ucanto/interface": "^3.0.0",
-    "multiformats": "^10.0.0",
+    "multiformats": "^10.0.2",
     "one-webcrypto": "^1.0.3"
   },
   "devDependencies": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -45,7 +45,7 @@
     "chai": "^4.3.6",
     "chai-subset": "^1.6.0",
     "mocha": "^10.1.0",
-    "multiformats": "^10.0.0",
+    "multiformats": "^10.0.2",
     "nyc": "^15.1.0",
     "playwright-test": "^8.1.1",
     "typescript": "^4.8.4"

--- a/packages/transport/package.json
+++ b/packages/transport/package.json
@@ -33,7 +33,7 @@
     "@ipld/dag-cbor": "^8.0.0",
     "@ucanto/core": "^3.0.1",
     "@ucanto/interface": "^3.0.0",
-    "multiformats": "^10.0.0"
+    "multiformats": "^10.0.2"
   },
   "devDependencies": {
     "@types/chai": "^4.3.3",

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -31,7 +31,7 @@
     "@ipld/dag-cbor": "^8.0.0",
     "@ucanto/core": "^3.0.1",
     "@ucanto/interface": "^3.0.0",
-    "multiformats": "^10.0.0"
+    "multiformats": "^10.0.2"
   },
   "devDependencies": {
     "@types/chai": "^4.3.3",

--- a/packages/validator/src/capability.js
+++ b/packages/validator/src/capability.js
@@ -635,17 +635,23 @@ class AndMatch {
 }
 
 /**
+ * Parses capability `source` using a provided capability `parser`. By default
+ * invocation parsing occurs, which respects a capability schema, failing if
+ * any non-optional field is missing. If `optional` argument is `true` it will
+ * parse capability as delegation, in this case all `nb` fields are considered
+ * optional.
+ *
  * @template {API.Ability} A
  * @template {API.URI} R
  * @template {API.Caveats} C
- * @param {{descriptor: API.Descriptor<A, R, C>}} self
+ * @param {{descriptor: API.Descriptor<A, R, C>}} parser
  * @param {API.Source} source
- * @param {boolean} optional
+ * @param {boolean} [optional=false]
  * @returns {API.Result<API.ParsedCapability<A, R, API.InferCaveats<C>>, API.InvalidCapability>}
  */
 
-const parse = (self, source, optional = false) => {
-  const { can, with: withReader, nb: readers } = self.descriptor
+const parse = (parser, source, optional = false) => {
+  const { can, with: withReader, nb: readers } = parser.descriptor
   const { delegation } = source
   const capability = /** @type {API.Capability<A, R, API.InferCaveats<C>>} */ (
     source.capability

--- a/packages/validator/src/capability.js
+++ b/packages/validator/src/capability.js
@@ -768,8 +768,8 @@ const selectGroup = (self, capabilities) => {
  * @template {API.Ability} A
  * @template {API.URI} R
  * @template {API.Caveats} C
- * @param {API.ParsedCapability<A, R, API.InferCaveats<C>>} claimed
- * @param {API.ParsedCapability<A, R, API.InferCaveats<C>>} delegated
+ * @param {API.ParsedCapability<A, R, Partial<API.InferCaveats<C>>>} claimed
+ * @param {API.ParsedCapability<A, R, Partial<API.InferCaveats<C>>>} delegated
  * @return {API.Result<true, API.Failure>}
  */
 const derives = (claimed, delegated) => {

--- a/packages/validator/src/capability.js
+++ b/packages/validator/src/capability.js
@@ -335,7 +335,7 @@ class Derive extends Unit {
   /**
    * @param {API.MatchSelector<M>} from
    * @param {API.TheCapabilityParser<API.DirectMatch<T>>} to
-   * @param {API.Derives<T, M['value']>} derives
+   * @param {API.Derives<API.ToDeriveClaim<T>, API.ToDeriveProof<M['value']>>} derives
    */
   constructor(from, to, derives) {
     super()
@@ -479,7 +479,7 @@ class DerivedMatch {
   /**
    * @param {API.DirectMatch<T>} selected
    * @param {API.MatchSelector<M>} from
-   * @param {API.Derives<T, M['value']>} derives
+   * @param {API.Derives<API.ToDeriveClaim<T>, API.ToDeriveProof<M['value']>>} derives
    */
   constructor(selected, from, derives) {
     this.selected = selected
@@ -765,11 +765,10 @@ const selectGroup = (self, capabilities) => {
 }
 
 /**
- * @template {API.Ability} A
- * @template {API.URI} R
- * @template {API.Caveats} C
- * @param {API.ParsedCapability<A, R, Partial<API.InferCaveats<C>>>} claimed
- * @param {API.ParsedCapability<A, R, Partial<API.InferCaveats<C>>>} delegated
+ * @template {API.ParsedCapability} T
+ * @template {API.ParsedCapability} U
+ * @param {T} claimed
+ * @param {U} delegated
  * @return {API.Result<true, API.Failure>}
  */
 const derives = (claimed, delegated) => {

--- a/packages/validator/test/capability.spec.js
+++ b/packages/validator/test/capability.spec.js
@@ -1669,16 +1669,6 @@ test('.and(...).match', () => {
           message: 'Constraint violation: a: a violates A',
         },
       },
-      {
-        name: 'InvalidClaim',
-        cause: {
-          name: 'MalformedCapability',
-          cause: {
-            name: 'TypeError',
-            message: 'Expected value of type string instead got undefined',
-          },
-        },
-      },
     ],
     matches: [
       {

--- a/packages/validator/test/delegate.spec.js
+++ b/packages/validator/test/delegate.spec.js
@@ -17,14 +17,17 @@ const echo = capability({
 
 test('delegate can omit constraints', async () => {
   assert.deepEqual(
-    await echo.delegate({
-      issuer: alice,
-      audience: w3,
-      with: alice.did(),
-      nb: {
-        message: 'data:1',
-      },
-    }),
+    /** @type {API.Delegation} */
+    (
+      await echo.delegate({
+        issuer: alice,
+        audience: w3,
+        with: alice.did(),
+        nb: {
+          message: 'data:1',
+        },
+      })
+    ),
     await delegate({
       issuer: alice,
       audience: w3,

--- a/packages/validator/test/inference.spec.js
+++ b/packages/validator/test/inference.spec.js
@@ -120,3 +120,125 @@ test('infers nb fields optional', () => {
     },
   })
 })
+
+test('infers nb fields in derived capability', () => {
+  capability({
+    can: 'test/base',
+    with: DID.match({ method: 'key' }),
+    nb: {
+      msg: URI.match({ protocol: 'data:' }),
+    },
+  }).derive({
+    to: capability({
+      can: 'test/derived',
+      with: DID.match({ method: 'key' }),
+      nb: {
+        bar: URI.match({ protocol: 'data:' }),
+      },
+    }),
+    derives: (claim, proof) => {
+      /** @type {string} */
+      // @ts-expect-error - may be undenfined
+      const _1 = claim.nb.bar
+
+      /** @type {API.URI<"data:">|undefined} */
+      const _2 = claim.nb.bar
+
+      /** @type {string} */
+      // @ts-expect-error - may be undenfined
+      const _3 = proof.nb.msg
+
+      /** @type {API.URI<"data:">|undefined} */
+      const _4 = proof.nb.msg
+
+      return true
+    },
+  })
+})
+
+test('infers nb fields in derived capability', () => {
+  const A = capability({
+    can: 'test/a',
+    with: DID.match({ method: 'key' }),
+    nb: {
+      a: URI.match({ protocol: 'data:' }),
+    },
+  })
+
+  const B = capability({
+    can: 'test/b',
+    with: DID.match({ method: 'key' }),
+    nb: {
+      b: URI.match({ protocol: 'data:' }),
+    },
+  })
+
+  A.and(B).derive({
+    to: capability({
+      can: 'test/c',
+      with: DID.match({ method: 'key' }),
+      nb: {
+        c: URI.match({ protocol: 'data:' }),
+      },
+    }),
+    derives: (claim, [a, b]) => {
+      /** @type {string} */
+      // @ts-expect-error - may be undenfined
+      const _1 = claim.nb.c
+
+      /** @type {API.URI<"data:">|undefined} */
+      const _2 = claim.nb.c
+
+      /** @type {string} */
+      // @ts-expect-error - may be undenfined
+      const _3 = a.nb.a
+
+      /** @type {API.URI<"data:">|undefined} */
+      const _4 = a.nb.a
+
+      /** @type {string} */
+      // @ts-expect-error - may be undenfined
+      const _5 = b.nb.b
+
+      /** @type {API.URI<"data:">|undefined} */
+      const _6 = b.nb.b
+
+      return true
+    },
+  })
+
+  test('infers nb fields in derived capability', async () => {
+    const A = capability({
+      can: 'test/a',
+      with: DID.match({ method: 'key' }),
+      nb: {
+        a: URI.match({ protocol: 'data:' }),
+      },
+    })
+
+    const a = await A.delegate({
+      issuer: alice,
+      with: alice.did(),
+      audience: w3,
+    })
+
+    /** @type {string} */
+    // @ts-expect-error - may be undenfined
+    const _1 = a.capabilities[0].nb.a
+
+    /** @type {string|undefined} */
+    const _2 = a.capabilities[0].nb.a
+
+    const i = A.invoke({
+      issuer: alice,
+      with: alice.did(),
+      audience: w3,
+      nb: {
+        a: 'data:',
+      },
+    })
+
+    /** @type {string} */
+    const _3 = i.capabilities[0].nb.a
+  })
+})

--- a/packages/validator/test/inference.spec.js
+++ b/packages/validator/test/inference.spec.js
@@ -103,14 +103,14 @@ test('infers nb fields optional', () => {
     },
     derives: (claim, proof) => {
       /** @type {string} */
-      // @ts-expect-error - may be undenfined
+      // @ts-expect-error - may be undefined
       const _1 = claim.nb.msg
 
       /** @type {API.URI<"data:">|undefined} */
       const _2 = claim.nb.msg
 
       /** @type {string} */
-      // @ts-expect-error - may be undenfined
+      // @ts-expect-error - may be undefined
       const _3 = proof.nb.msg
 
       /** @type {API.URI<"data:">|undefined} */
@@ -138,14 +138,14 @@ test('infers nb fields in derived capability', () => {
     }),
     derives: (claim, proof) => {
       /** @type {string} */
-      // @ts-expect-error - may be undenfined
+      // @ts-expect-error - may be undefined
       const _1 = claim.nb.bar
 
       /** @type {API.URI<"data:">|undefined} */
       const _2 = claim.nb.bar
 
       /** @type {string} */
-      // @ts-expect-error - may be undenfined
+      // @ts-expect-error - may be undefined
       const _3 = proof.nb.msg
 
       /** @type {API.URI<"data:">|undefined} */
@@ -183,21 +183,21 @@ test('infers nb fields in derived capability', () => {
     }),
     derives: (claim, [a, b]) => {
       /** @type {string} */
-      // @ts-expect-error - may be undenfined
+      // @ts-expect-error - may be undefined
       const _1 = claim.nb.c
 
       /** @type {API.URI<"data:">|undefined} */
       const _2 = claim.nb.c
 
       /** @type {string} */
-      // @ts-expect-error - may be undenfined
+      // @ts-expect-error - may be undefined
       const _3 = a.nb.a
 
       /** @type {API.URI<"data:">|undefined} */
       const _4 = a.nb.a
 
       /** @type {string} */
-      // @ts-expect-error - may be undenfined
+      // @ts-expect-error - may be undefined
       const _5 = b.nb.b
 
       /** @type {API.URI<"data:">|undefined} */
@@ -223,7 +223,7 @@ test('infers nb fields in derived capability', () => {
     })
 
     /** @type {string} */
-    // @ts-expect-error - may be undenfined
+    // @ts-expect-error - may be undefined
     const _1 = a.capabilities[0].nb.a
 
     /** @type {string|undefined} */

--- a/packages/validator/test/inference.spec.js
+++ b/packages/validator/test/inference.spec.js
@@ -1,7 +1,7 @@
 import * as Voucher from './voucher.js'
 import { test, assert } from './test.js'
 import { alice, bob, mallory, service as w3 } from './fixtures.js'
-import { capability, URI, Link } from '../src/lib.js'
+import { capability, URI, Link, DID } from '../src/lib.js'
 import * as API from './types.js'
 
 test('execute capabilty', () =>
@@ -93,3 +93,30 @@ test('use InferInvokedCapability', () =>
       result.product.toLocaleLowerCase()
     }
   })
+
+test('infers nb fields optional', () => {
+  capability({
+    can: 'test/nb',
+    with: DID.match({ method: 'key' }),
+    nb: {
+      msg: URI.match({ protocol: 'data:' }),
+    },
+    derives: (claim, proof) => {
+      /** @type {string} */
+      // @ts-expect-error - may be undenfined
+      const _1 = claim.nb.msg
+
+      /** @type {API.URI<"data:">|undefined} */
+      const _2 = claim.nb.msg
+
+      /** @type {string} */
+      // @ts-expect-error - may be undenfined
+      const _3 = proof.nb.msg
+
+      /** @type {API.URI<"data:">|undefined} */
+      const _4 = proof.nb.msg
+
+      return true
+    },
+  })
+})

--- a/packages/validator/test/util.js
+++ b/packages/validator/test/util.js
@@ -9,17 +9,36 @@ export const fail = value => (value === true ? undefined : value)
 /**
  * Check URI can be delegated
  *
- * @param {string} child
- * @param {string} parent
+ * @param {string|undefined} child
+ * @param {string|undefined} parent
  */
 export function canDelegateURI(child, parent) {
-  if (parent.endsWith('*')) {
+  if (parent === undefined) {
+    return true
+  }
+
+  if (child !== undefined && parent.endsWith('*')) {
     return child.startsWith(parent.slice(0, -1))
       ? true
       : new Failure(`${child} does not match ${parent}`)
   }
 
   return child === parent
+    ? true
+    : new Failure(`${child} is different from ${parent}`)
+}
+
+/**
+ * @param {API.Link<unknown, number, number, 0|1>|undefined} child
+ * @param {API.Link<unknown, number, number, 0|1>|undefined} parent
+ */
+export const canDelegateLink = (child, parent) => {
+  // if parent poses no restriction it's can be derived
+  if (parent === undefined) {
+    return true
+  }
+
+  return String(child) === parent.toString()
     ? true
     : new Failure(`${child} is different from ${parent}`)
 }

--- a/packages/validator/test/voucher.js
+++ b/packages/validator/test/voucher.js
@@ -1,4 +1,4 @@
-import { equalWith, canDelegateURI, fail } from './util.js'
+import { equalWith, canDelegateURI, canDelegateLink, fail } from './util.js'
 import { capability, URI, Text, Link, DID } from '../src/lib.js'
 
 export const Voucher = capability({
@@ -19,12 +19,7 @@ export const Claim = Voucher.derive({
       return (
         fail(equalWith(child, parent)) ||
         fail(canDelegateURI(child.nb.identity, parent.nb.identity)) ||
-        fail(
-          canDelegateURI(
-            child.nb.product.toString(),
-            parent.nb.product.toString()
-          )
-        ) ||
+        fail(canDelegateLink(child.nb.product, parent.nb.product)) ||
         fail(canDelegateURI(child.nb.service, parent.nb.service)) ||
         true
       )

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,7 +1,7 @@
 lockfileVersion: 5.4
 
 overrides:
-  multiformats: ^10.0.0
+  multiformats: ^10.0.2
 
 importers:
 
@@ -28,13 +28,13 @@ importers:
       c8: ^7.11.0
       chai: ^4.3.6
       mocha: ^10.1.0
-      multiformats: ^10.0.0
+      multiformats: ^10.0.2
       nyc: ^15.1.0
       playwright-test: ^8.1.1
       typescript: ^4.8.4
     dependencies:
       '@ucanto/interface': link:../interface
-      multiformats: 10.0.0
+      multiformats: 10.0.2
     devDependencies:
       '@types/chai': 4.3.3
       '@types/mocha': 9.1.1
@@ -62,7 +62,7 @@ importers:
       c8: ^7.11.0
       chai: ^4.3.6
       mocha: ^10.1.0
-      multiformats: ^10.0.0
+      multiformats: ^10.0.2
       nyc: ^15.1.0
       playwright-test: ^8.1.1
       typescript: ^4.8.4
@@ -71,7 +71,7 @@ importers:
       '@ipld/dag-cbor': 8.0.0
       '@ipld/dag-ucan': 2.0.0
       '@ucanto/interface': link:../interface
-      multiformats: 10.0.0
+      multiformats: 10.0.2
     devDependencies:
       '@types/chai': 4.3.3
       '@types/mocha': 9.1.1
@@ -86,11 +86,11 @@ importers:
   packages/interface:
     specifiers:
       '@ipld/dag-ucan': ^2.0.0
-      multiformats: ^10.0.0
+      multiformats: ^10.0.2
       typescript: ^4.8.4
     dependencies:
       '@ipld/dag-ucan': 2.0.0
-      multiformats: 10.0.0
+      multiformats: 10.0.2
     devDependencies:
       typescript: 4.8.4
 
@@ -104,7 +104,7 @@ importers:
       c8: ^7.11.0
       chai: ^4.3.6
       mocha: ^10.1.0
-      multiformats: ^10.0.0
+      multiformats: ^10.0.2
       nyc: ^15.1.0
       one-webcrypto: ^1.0.3
       playwright-test: ^8.1.1
@@ -113,7 +113,7 @@ importers:
       '@ipld/dag-ucan': 2.0.0
       '@noble/ed25519': 1.7.1
       '@ucanto/interface': link:../interface
-      multiformats: 10.0.0
+      multiformats: 10.0.2
       one-webcrypto: 1.0.3
     devDependencies:
       '@types/chai': 4.3.3
@@ -142,7 +142,7 @@ importers:
       chai: ^4.3.6
       chai-subset: ^1.6.0
       mocha: ^10.1.0
-      multiformats: ^10.0.0
+      multiformats: ^10.0.2
       nyc: ^15.1.0
       playwright-test: ^8.1.1
       typescript: ^4.8.4
@@ -163,7 +163,7 @@ importers:
       chai: 4.3.6
       chai-subset: 1.6.0
       mocha: 10.1.0
-      multiformats: 10.0.0
+      multiformats: 10.0.2
       nyc: 15.1.0
       playwright-test: 8.1.1
       typescript: 4.8.4
@@ -181,7 +181,7 @@ importers:
       c8: ^7.11.0
       chai: ^4.3.6
       mocha: ^10.1.0
-      multiformats: ^10.0.0
+      multiformats: ^10.0.2
       nyc: ^15.1.0
       playwright-test: ^8.1.1
       typescript: ^4.8.4
@@ -190,7 +190,7 @@ importers:
       '@ipld/dag-cbor': 8.0.0
       '@ucanto/core': link:../core
       '@ucanto/interface': link:../interface
-      multiformats: 10.0.0
+      multiformats: 10.0.2
     devDependencies:
       '@types/chai': 4.3.3
       '@types/mocha': 9.1.1
@@ -218,7 +218,7 @@ importers:
       chai: ^4.3.6
       chai-subset: ^1.6.0
       mocha: ^10.1.0
-      multiformats: ^10.0.0
+      multiformats: ^10.0.2
       nyc: ^15.1.0
       playwright-test: ^8.1.1
       typescript: ^4.8.4
@@ -227,7 +227,7 @@ importers:
       '@ipld/dag-cbor': 8.0.0
       '@ucanto/core': link:../core
       '@ucanto/interface': link:../interface
-      multiformats: 10.0.0
+      multiformats: 10.0.2
     devDependencies:
       '@types/chai': 4.3.3
       '@types/chai-subset': 1.3.3
@@ -454,7 +454,7 @@ packages:
     dependencies:
       '@ipld/dag-cbor': 8.0.0
       cborg: 1.9.5
-      multiformats: 10.0.0
+      multiformats: 10.0.2
       varint: 6.0.0
     dev: false
 
@@ -462,7 +462,7 @@ packages:
     resolution: {integrity: sha512-1VVh2huHsuohdXC1bGJNE8WR72slZ9XE2T3wbBBq31dm7ZBatmKLLxrB+XAqafxfRFjv08RZmj/W/ZqaM13AuA==}
     dependencies:
       cborg: 1.9.5
-      multiformats: 10.0.0
+      multiformats: 10.0.2
     dev: false
 
   /@ipld/dag-cbor/8.0.0:
@@ -470,14 +470,14 @@ packages:
     engines: {node: '>=16.0.0', npm: '>=7.0.0'}
     dependencies:
       cborg: 1.9.5
-      multiformats: 10.0.0
+      multiformats: 10.0.2
     dev: false
 
   /@ipld/dag-json/8.0.11:
     resolution: {integrity: sha512-Pea7JXeYHTWXRTIhBqBlhw7G53PJ7yta3G/sizGEZyzdeEwhZRr0od5IQ0r2ZxOt1Do+2czddjeEPp+YTxDwCA==}
     dependencies:
       cborg: 1.9.5
-      multiformats: 10.0.0
+      multiformats: 10.0.2
     dev: false
 
   /@ipld/dag-ucan/2.0.0:
@@ -485,7 +485,7 @@ packages:
     dependencies:
       '@ipld/dag-cbor': 7.0.3
       '@ipld/dag-json': 8.0.11
-      multiformats: 10.0.0
+      multiformats: 10.0.2
     dev: false
 
   /@istanbuljs/load-nyc-config/1.1.0:
@@ -2231,8 +2231,8 @@ packages:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
     dev: true
 
-  /multiformats/10.0.0:
-    resolution: {integrity: sha512-qEj/ansAK86ufzupmp8B/JbiNSLJhNFcqW2Aa1dWxQc0OfoorpknwKkJeXAbtZ62AJlA6qKsGrCY3OjdFWZOrQ==}
+  /multiformats/10.0.2:
+    resolution: {integrity: sha512-nJEHLFOYhO4L+aNApHhCnWqa31FyqAHv9Q77AhmwU3KsM2f1j7tuJpCk5ByZ33smzycNCpSG5klNIejIyfFx2A==}
     engines: {node: '>=16.0.0', npm: '>=7.0.0'}
 
   /nanoid/3.3.3:


### PR DESCRIPTION
Fixes #123 


### Overview

- [x] Adds `optional` parameter to the `parse` function used by validator to parse capabilities.
- [x] `.select` method which selects matching proofs from delegation chain passes `option:true` to parser so `nb` fields are never required in delegations.
- [x] `derives` of the capability infers type `nb` fields as optionals.
- [x] `derives` in `cap.derive({ to, derives })` infers `nb` fields as optionals.
- [x] `.delegate(opts).capabilities[0].nb` infers fields as optionals.
- [x] `.invoke(opts).capabilities[0].nb` infers fields as defined in schema.

---

I hate introducing more utility types to make this work, but unfortunately there was no simple way to fix all the problems. It is possible to rework validator such that we would be able to remove bunch of these utility types, however it is non trivial change and I'd rather do it later on when there's less urgency.