### PR TITLE
feat: did:dns support

### DIFF
--- a/packages/interface/src/lib.ts
+++ b/packages/interface/src/lib.ts
@@ -422,11 +422,19 @@ export interface Signer<M extends string = string, A extends number = number>
    * }
    * ```
    */
-  toArchive(): SignerArchive<Signer<M, A>>
+  toArchive(): SignerArchive<this>
 }
 
 export interface SignerInfo<Self extends Signer = Signer> {
+  /**
+   * DID that is returned by .did() method of the signer.
+   */
   readonly did: ReturnType<Self['did']>
+  /**
+   * If .did() returns non did:key (e.g did:dns) this field will
+   * contain did:key it resolves to, otherwise it is omitted.
+   */
+  readonly resolvedDID?: DID<'key'>
   readonly key: CryptoKey
 }
 

--- a/packages/principal/src/dns.js
+++ b/packages/principal/src/dns.js
@@ -1,0 +1,5 @@
+export * as API from './dns/type.js'
+export { create as createVerifier, parse } from './dns/verifier.js'
+export { create as createSigner, from, generate } from './dns/signer.js'
+
+export * as Verifier from './dns/verifier.js'

--- a/packages/principal/src/dns/signer.js
+++ b/packages/principal/src/dns/signer.js
@@ -52,7 +52,7 @@ export const from = (
 
     return new Signer(signer, Verifier.create(archive.did, verifier))
   } else {
-    throw new RangeError(`did:dns archive expected to have resolveDID field`)
+    throw new RangeError(`did:dns archive expected to have resolvedDID field`)
   }
 }
 

--- a/packages/principal/src/dns/signer.js
+++ b/packages/principal/src/dns/signer.js
@@ -1,0 +1,145 @@
+import * as API from './type.js'
+import * as Verifier from './verifier.js'
+import * as Key from '../key.js'
+import * as ed25519 from '../ed25519.js'
+import { encodingLength, encodeTo, decode } from '../multiformat.js'
+
+const UTF8Encoder = new TextEncoder()
+const UTF8Decoder = new TextDecoder()
+
+// DNS multiaddr code
+const CODE = 0x35
+
+/**
+ * @param {API.SignerArchive<API.Signer>} archive
+ * @param {Partial<API.SignerOptions>} options
+ * @returns {API.Signer}
+ */
+export const from = (
+  archive,
+  { parser = Key.Verifier, importer = Key.Signer } = {}
+) => {
+  if (archive instanceof Uint8Array) {
+    const codeSize = encodingLength(CODE)
+    const [length, lengthSize] = decode(archive, codeSize)
+    const offset = codeSize + lengthSize
+    const domain = UTF8Decoder.decode(
+      new Uint8Array(archive.buffer, offset, length)
+    )
+
+    const signer = importer.from(
+      new Uint8Array(archive.buffer, offset + length)
+    )
+
+    return new Signer(
+      /** @type {API.SigningPrincipal<"key">} */ (signer),
+      Verifier.create(`did:dns:${domain}`, signer.verifier)
+    )
+  } else if (!archive.did.startsWith('did:dns:')) {
+    throw new RangeError(`Expeted did:dns identifer instead got ${archive.did}`)
+  } else if (archive.resolvedDID) {
+    const verifier = parser.parse(archive.resolvedDID)
+    const signer = /** @type {API.SigningPrincipal<"key">} */ (
+      importer.from({
+        did: archive.resolvedDID,
+        key: archive.key,
+      })
+    )
+    return new Signer(signer, Verifier.create(archive.did, verifier))
+  } else {
+    throw new RangeError(`did:dns archive expected to have resolveDID field`)
+  }
+}
+
+/**
+ * @template {number} Code
+ * @param {string} domain
+ * @param {{generate(): API.Await<{ signer: API.SigningPrincipal<'key', Code>, verifier: API.UCAN.Verifier<'key', Code> }>}} generator
+ */
+export const generate = async (domain, generator = ed25519) =>
+  create(domain, await generator.generate())
+
+/**
+ * @template {number} Code
+ * @param {string} domain
+ * @param {object} options
+ * @param {API.SigningPrincipal<'key', Code>} options.signer
+ * @param {API.UCAN.Verifier<'key', Code>} options.verifier
+ */
+export const create = (domain, { signer, verifier }) =>
+  new Signer(signer, Verifier.create(`did:dns:${domain}`, verifier))
+
+/**
+ * @template {number} Code
+ * @implements {API.Signer<Code>}
+ */
+class Signer {
+  /**
+   * @param {API.SigningPrincipal<'key', Code>} signer
+   * @param {API.Verifier<Code>} verifier
+   */
+  constructor(signer, verifier) {
+    this._signer = signer
+    this.verifier = verifier
+  }
+  get signer() {
+    return this
+  }
+  get signatureAlgorithm() {
+    return this._signer.signatureAlgorithm
+  }
+  get signatureCode() {
+    return this._signer.signatureCode
+  }
+  did() {
+    return this.verifier.did()
+  }
+  /**
+   * @template T
+   * @param {API.ByteView<T>} payload
+   */
+  sign(payload) {
+    return this._signer.sign(payload)
+  }
+  /**
+   * @template T
+   * @param {API.ByteView<T>} payload
+   * @param {API.Signature<T, Code>} signature
+   */
+  verify(payload, signature) {
+    return this.verifier.verify(payload, signature)
+  }
+
+  /**
+   *
+   * @returns {API.SignerArchive<API.SigningPrincipal<'dns', Code>>}
+   */
+  toArchive() {
+    const archive = this._signer.toArchive()
+    if (archive instanceof Uint8Array) {
+      const domain = UTF8Encoder.encode(this.did().slice('did:dns:'.length))
+
+      const codeSize = encodingLength(CODE)
+      const lengthSize = encodingLength(domain.length)
+      const length = codeSize + lengthSize + domain.length + archive.length
+      const bytes = new Uint8Array(length)
+
+      let offset = 0
+      encodeTo(CODE, bytes, offset)
+      offset += codeSize
+      encodeTo(domain.length, bytes, offset)
+      offset += lengthSize
+      bytes.set(domain, offset)
+      offset += domain.length
+      bytes.set(archive, offset)
+
+      return bytes
+    } else {
+      return {
+        did: this.did(),
+        resolvedDID: archive.did,
+        key: archive.key,
+      }
+    }
+  }
+}

--- a/packages/principal/src/dns/type.ts
+++ b/packages/principal/src/dns/type.ts
@@ -8,6 +8,15 @@ import {
 } from '@ucanto/interface'
 export * from '@ucanto/interface'
 
+export interface SigningPrincipalGenerator<Code extends number> {
+  generate(): Await<KeySigner<Code>>
+}
+
+export interface KeySigner<Code extends number, M extends string = 'key'> {
+  signer: SigningPrincipal<M, Code>
+  verifier: UCAN.Verifier<M, Code>
+}
+
 export interface Signer<Code extends number = number>
   extends SigningPrincipal<'dns', Code>,
     UCAN.Verifier<'dns', Code> {

--- a/packages/principal/src/dns/type.ts
+++ b/packages/principal/src/dns/type.ts
@@ -1,0 +1,35 @@
+import {
+  Signer as SigningPrincipal,
+  SignerImporter,
+  PrincipalParser,
+  UCAN,
+  DID,
+  Await,
+} from '@ucanto/interface'
+export * from '@ucanto/interface'
+
+export interface Signer<Code extends number = number>
+  extends SigningPrincipal<'dns', Code>,
+    UCAN.Verifier<'dns', Code> {
+  readonly signer: Signer<Code>
+  readonly verifier: Verifier<Code>
+
+  resolve(): SigningPrincipal<'key', Code>
+}
+
+export interface Verifier<Code extends number = number>
+  extends UCAN.Verifier<'dns', Code> {
+  resolve(): Await<UCAN.Verifier<'key', Code>>
+}
+
+export interface VerifierOptions {
+  resolve(did: DID<'dns'>): Await<DID<'key'>>
+  parser: PrincipalParser
+}
+
+export interface SignerOptions {
+  importer: SignerImporter
+  parser: PrincipalParser
+}
+
+export type { SigningPrincipal }

--- a/packages/principal/src/dns/verifier.js
+++ b/packages/principal/src/dns/verifier.js
@@ -1,0 +1,124 @@
+import * as API from './type.js'
+import { Verifier as KeyVerifier } from '../key.js'
+
+/**
+ *
+ * @param {API.DID<"dns">} did
+ */
+const notFound = did => {
+  throw new RangeError(`Unable to reslove ${did}`)
+}
+
+/**
+ * @param {API.DID} source
+ * @param {Partial<API.VerifierOptions>} options
+ * @returns {API.Verifier}
+ */
+export const parse = (
+  source,
+  { parser = KeyVerifier, resolve = notFound } = {}
+) => {
+  if (!source.startsWith('did:dns:')) {
+    throw new RangeError(`Expeted did:dns identifer instead got ${source}`)
+  }
+  return new Verifier(/** @type {API.DID<'dns'>} */ (source), null, {
+    parser,
+    resolve,
+  })
+}
+
+/**
+ * @template {number} Code
+ * @param {API.DID<"dns">} source
+ * @param {API.UCAN.Verifier<string, Code>} key
+ */
+export const create = (source, key) => new ResolvedVerifier(source, key)
+
+/**
+ * @template {number} Code
+ * @implements {API.Verifier<Code>}
+ */
+class ResolvedVerifier {
+  /**
+   * @param {API.DID<"dns">} source
+   * @param {API.UCAN.Verifier<"key", Code>} inner
+   */
+  constructor(source, inner) {
+    this.source = source
+    this.inner = inner
+  }
+  did() {
+    return this.source
+  }
+  resolve() {
+    return this.inner
+  }
+  /**
+   * @template T
+   * @param {API.ByteView<T>} payload
+   * @param {API.Signature<T, Code>} signature
+   * @returns {API.Await<boolean>}
+   */
+  verify(payload, signature) {
+    return this.inner.verify(payload, signature)
+  }
+}
+
+/**
+ * @template {number} Code
+ * @implements {API.Verifier<Code>}
+ */
+class Verifier {
+  /**
+   * @param {API.DID<"dns">} source
+   * @param {API.UCAN.Verifier<"key", Code>|null} key
+   * @param {API.VerifierOptions} options
+   */
+  constructor(source, key, options) {
+    this.source = source
+    this.options = options
+    this.key = key
+  }
+  did() {
+    return this.source
+  }
+  /**
+   * @template T
+   * @param {API.ByteView<T>} payload
+   * @param {API.Signature<T, Code>} signature
+   * @returns {API.Await<boolean>}
+   */
+  verify(payload, signature) {
+    if (this.key) {
+      return this.key.verify(payload, signature)
+    } else {
+      return this.resolveAndVerify(payload, signature)
+    }
+  }
+
+  async resolve() {
+    if (!this.key) {
+      const did = await this.options.resolve(this.source)
+      this.key = /** @type {API.UCAN.Verifier<"key", Code>} */ (
+        this.options.parser.parse(did)
+      )
+    }
+    return this.key
+  }
+
+  /**
+   * @private
+   * @template T
+   * @param {API.ByteView<T>} payload
+   * @param {API.Signature<T, Code>} signature
+   * @returns {Promise<boolean>}
+   */
+  async resolveAndVerify(payload, signature) {
+    try {
+      const key = await this.resolve()
+      return key.verify(payload, signature)
+    } catch (_) {
+      return false
+    }
+  }
+}

--- a/packages/principal/src/dns/verifier.js
+++ b/packages/principal/src/dns/verifier.js
@@ -30,7 +30,7 @@ export const parse = (
 /**
  * @template {number} Code
  * @param {API.DID<"dns">} source
- * @param {API.UCAN.Verifier<string, Code>} key
+ * @param {API.UCAN.Verifier<"key", Code>} key
  */
 export const create = (source, key) => new ResolvedVerifier(source, key)
 

--- a/packages/principal/src/ed25519/type.ts
+++ b/packages/principal/src/ed25519/type.ts
@@ -11,9 +11,8 @@ export interface EdSigner<M extends string = 'key'>
     UCAN.Verifier<M, CODE> {
   readonly signer: EdSigner<M>
   readonly verifier: EdVerifier<M>
-
   readonly code: 0x1300
-  toArchive(): ByteView<EdSigner<M>>
+  toArchive(): ByteView<this>
 }
 
 export interface EdVerifier<M extends string = 'key'>

--- a/packages/principal/src/key.js
+++ b/packages/principal/src/key.js
@@ -1,0 +1,7 @@
+import * as ed25519 from './ed25519.js'
+import * as RSA from './rsa.js'
+import { create as createVerifier } from './verifier.js'
+import { create as createSigner } from './signer.js'
+
+export const Verifier = createVerifier([ed25519.Verifier, RSA.Verifier])
+export const Signer = createSigner([ed25519, RSA])

--- a/packages/principal/src/lib.js
+++ b/packages/principal/src/lib.js
@@ -1,9 +1,15 @@
 import * as ed25519 from './ed25519.js'
 import * as RSA from './rsa.js'
+import * as DNS from './dns.js'
+import * as Key from './key.js'
 import { create as createVerifier } from './verifier.js'
 import { create as createSigner } from './signer.js'
 
-export const Verifier = createVerifier([ed25519.Verifier, RSA.Verifier])
-export const Signer = createSigner([ed25519, RSA])
+export const Verifier = createVerifier([
+  ed25519.Verifier,
+  RSA.Verifier,
+  DNS.Verifier,
+])
+export const Signer = createSigner([ed25519, RSA, DNS])
 
-export { ed25519, RSA }
+export { ed25519, RSA, Key, DNS }

--- a/packages/principal/src/multiformat.js
+++ b/packages/principal/src/multiformat.js
@@ -33,3 +33,7 @@ export const untagWith = (code, source, byteOffset = 0) => {
     return new Uint8Array(bytes.buffer, bytes.byteOffset + size)
   }
 }
+
+export const encodingLength = varint.encodingLength
+export const encodeTo = varint.encodeTo
+export const decode = varint.decode

--- a/packages/principal/src/rsa.js
+++ b/packages/principal/src/rsa.js
@@ -294,8 +294,12 @@ class ExtractableRSASigner extends RSASigner {
     super(options)
     this.bytes = options.bytes
   }
+
+  /**
+   * @returns {API.ByteView<this>}
+   */
   toArchive() {
-    return this.bytes
+    return /** @type {API.ByteView<this>} */ (this.bytes)
   }
 }
 
@@ -312,10 +316,14 @@ class UnextractableRSASigner extends RSASigner {
     super(options)
     this.privateKey = options.privateKey
   }
+
+  /**
+   * @returns {API.SignerArchive<this>}
+   */
   toArchive() {
-    return {
+    return /** @type {API.SignerArchive<this>} */ ({
       did: this.did(),
       key: this.privateKey,
-    }
+    })
   }
 }

--- a/packages/principal/test/dns.spec.js
+++ b/packages/principal/test/dns.spec.js
@@ -1,9 +1,9 @@
 import { ed25519, RSA, DNS } from '../src/lib.js'
 import { assert } from 'chai'
 import { sha256 } from 'multiformats/hashes/sha2'
-import { varint } from 'multiformats'
+
 export const utf8 = new TextEncoder()
-describe.only('DNS', () => {
+describe('DNS', () => {
   it('generate', async () => {
     const signer = await DNS.generate('api.web3.storage', ed25519)
 
@@ -46,7 +46,8 @@ describe.only('DNS', () => {
 
   it('can archive 🔁 restore rsa extractable', async () => {
     const original = await DNS.generate('api.web3.storage', RSA)
-    const restored = DNS.from(original.toArchive())
+    const archive = original.toArchive()
+    const restored = DNS.from(archive)
     const payload = utf8.encode('hello world')
 
     assert.equal(
@@ -94,7 +95,7 @@ describe.only('DNS', () => {
     const payload = utf8.encode('hello world')
     const verifier = DNS.Verifier.parse(principal.did(), {
       resolve: async _dns => {
-        const verifier = await principal.verifier.resolve()
+        const verifier = await principal.resolve()
         return verifier.did()
       },
     })

--- a/packages/principal/test/dns.spec.js
+++ b/packages/principal/test/dns.spec.js
@@ -1,0 +1,105 @@
+import { ed25519, RSA, DNS } from '../src/lib.js'
+import { assert } from 'chai'
+import { sha256 } from 'multiformats/hashes/sha2'
+import { varint } from 'multiformats'
+export const utf8 = new TextEncoder()
+describe.only('DNS', () => {
+  it('generate', async () => {
+    const signer = await DNS.generate('api.web3.storage', ed25519)
+
+    assert.ok(signer.did().startsWith('did:dns:api.web3.storage'))
+    assert.equal(signer.signatureCode, 0xd0ed)
+    assert.equal(signer.signatureAlgorithm, 'EdDSA')
+    assert.equal(signer.signer, signer)
+
+    const payload = await sha256.encode(new TextEncoder().encode('hello world'))
+    const signature = await signer.sign(payload)
+
+    assert.equal(
+      await signer.verifier.verify(payload, signature),
+      true,
+      'signer can verify signature'
+    )
+    assert.equal(await signer.verify(payload, signature), true)
+
+    assert.equal(signer.signatureAlgorithm, 'EdDSA')
+    assert.equal(signer.signatureCode, 0xd0ed)
+    assert.equal(signer.did(), signer.verifier.did())
+  })
+
+  it('can archive 🔁 restore rsa unextractable', async () => {
+    const original = await DNS.generate('api.web3.storage', RSA)
+    const archive = original.toArchive()
+    const restored = DNS.from(archive)
+    const payload = utf8.encode('hello world')
+
+    assert.equal(
+      await restored.verify(payload, await original.sign(payload)),
+      true
+    )
+
+    assert.equal(
+      await original.verify(payload, await restored.sign(payload)),
+      true
+    )
+  })
+
+  it('can archive 🔁 restore rsa extractable', async () => {
+    const original = await DNS.generate('api.web3.storage', RSA)
+    const restored = DNS.from(original.toArchive())
+    const payload = utf8.encode('hello world')
+
+    assert.equal(
+      await restored.verify(payload, await original.sign(payload)),
+      true
+    )
+
+    assert.equal(
+      await original.verify(payload, await restored.sign(payload)),
+      true
+    )
+  })
+
+  it('can archive 🔁 restore ed25519', async () => {
+    const original = await DNS.generate('api.web3.storage', ed25519)
+    const restored = DNS.from(original.toArchive())
+    const payload = utf8.encode('hello world')
+
+    assert.equal(
+      await restored.verify(payload, await original.sign(payload)),
+      true
+    )
+
+    assert.equal(
+      await original.verify(payload, await restored.sign(payload)),
+      true
+    )
+  })
+
+  it('can sign & verify', async () => {
+    const signer = await DNS.generate('web3.storage')
+    const payload = utf8.encode('hello world')
+
+    const signature = await signer.sign(payload)
+    assert.equal(signature.code, signer.signatureCode)
+    assert.equal(signature.algorithm, signer.signatureAlgorithm)
+
+    const { verifier } = signer
+    assert.equal(await verifier.verify(payload, signature), true)
+    assert.equal(await signer.verify(payload, signature), true)
+  })
+
+  it('can parse verifier', async () => {
+    const principal = await DNS.generate('api.web3.storage')
+    const payload = utf8.encode('hello world')
+    const verifier = DNS.Verifier.parse(principal.did(), {
+      resolve: async _dns => {
+        const verifier = await principal.verifier.resolve()
+        return verifier.did()
+      },
+    })
+
+    const signature = await principal.sign(payload)
+    assert.equal(await verifier.verify(payload, signature), true)
+  })
+})

--- a/packages/principal/test/rsa.spec.js
+++ b/packages/principal/test/rsa.spec.js
@@ -46,8 +46,8 @@ describe('RSA', () => {
 
   it('can archive 🔁 restore unextractable', async () => {
     const original = await RSA.generate()
-    const bytes = original.toArchive()
-    const restored = RSA.from(bytes)
+    const archive = original.toArchive()
+    const restored = RSA.from(archive)
     const payload = utf8.encode('hello world')
 
     assert.equal(


### PR DESCRIPTION
Fixes #137

Adds a new DNS principal which:

1. Can be a simple wrapper around other principals
2. Who's `Validator` can  be passed custom `resolve` handler to allow key resolution via DNSLookup or other means.