### PR TITLE
fix: export types from @ucanto/principal/ed25519 like it used to be

### DIFF
--- a/packages/principal/src/ed25519.js
+++ b/packages/principal/src/ed25519.js
@@ -1,4 +1,3 @@
 export * from './ed25519/signer.js'
 export * as Verifier from './ed25519/verifier.js'
 export * as Signer from './ed25519/signer.js'
-export * from "./ed25519/type.js"

--- a/packages/principal/src/ed25519.js
+++ b/packages/principal/src/ed25519.js
@@ -1,3 +1,4 @@
 export * from './ed25519/signer.js'
 export * as Verifier from './ed25519/verifier.js'
 export * as Signer from './ed25519/signer.js'
+export * from "./ed25519/type.js"

--- a/packages/principal/src/ed25519/signer.js
+++ b/packages/principal/src/ed25519/signer.js
@@ -21,6 +21,11 @@ const SIZE = PRIVATE_TAG_SIZE + KEY_SIZE + PUBLIC_TAG_SIZE + KEY_SIZE
 export const PUB_KEY_OFFSET = PRIVATE_TAG_SIZE + KEY_SIZE
 
 /**
+ * EdSigner type is exported here for others to use.
+ * @typedef {API.EdSigner} EdSigner
+ */
+
+/**
  * Generates new issuer by generating underlying ED25519 keypair.
  * @returns {Promise<API.EdSigner>}
  */


### PR DESCRIPTION
Motivation:
* w3protocol depended on this export (for EdSigner) but it got [dropped](https://github.com/web3-storage/ucanto/commit/4c11092e420292af697bd5bec126112f9b961612#diff-584f753a960081eb7a7d9bb3100b4da1cafba8358c4b5d45923a56a6163cf07aL20) in 4.0.0 