### PR TITLE
fix: toJSON behavior on the ucan.data

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@ipld/car": "^5.0.0",
     "@ipld/dag-cbor": "^8.0.0",
-    "@ipld/dag-ucan": "^3.0.1",
+    "@ipld/dag-ucan": "^3.1.1",
     "@ucanto/interface": "^4.0.3",
     "multiformats": "^10.0.2"
   },

--- a/packages/core/test/delegation.spec.js
+++ b/packages/core/test/delegation.spec.js
@@ -1,0 +1,134 @@
+import { assert, test } from './test.js'
+import { Delegation, UCAN, isDelegation, parseLink } from '../src/lib.js'
+import { alice, bob, mallory, service } from './fixtures.js'
+import { base64 } from 'multiformats/bases/base64'
+const utf8 = new TextEncoder()
+
+const link = parseLink(
+  'bafybeid4cy7pj33wuead6zioxdtx3zwalhr6hd572tgqubgmy2ahrmi6vu'
+)
+/**
+ * @param {unknown} value
+ */
+const toJSON = value => JSON.parse(JSON.stringify(value))
+
+test('delegation.data.toJSON', async () => {
+  const ucan = await Delegation.delegate({
+    issuer: alice,
+    audience: bob,
+    capabilities: [
+      {
+        can: 'store/add',
+        with: alice.did(),
+      },
+    ],
+  })
+
+  assert.deepEqual(toJSON(ucan.data), {
+    v: UCAN.VERSION,
+    iss: alice.did(),
+    aud: bob.did(),
+    att: [
+      {
+        can: 'store/add',
+        with: alice.did(),
+      },
+    ],
+    exp: ucan.expiration,
+    prf: [],
+    s: { '/': { bytes: base64.baseEncode(ucan.signature) } },
+  })
+})
+
+test('delegation.data.toJSON with proofs', async () => {
+  const proof = await Delegation.delegate({
+    issuer: alice,
+    audience: bob,
+    capabilities: [
+      {
+        can: 'store/add',
+        with: alice.did(),
+      },
+    ],
+  })
+
+  const ucan = await Delegation.delegate({
+    issuer: bob,
+    audience: mallory,
+    capabilities: [
+      {
+        can: 'store/add',
+        with: alice.did(),
+        root: link,
+      },
+    ],
+    proofs: [proof],
+  })
+
+  assert.deepEqual(toJSON(ucan.data), {
+    v: UCAN.VERSION,
+    iss: bob.did(),
+    aud: mallory.did(),
+    att: [
+      {
+        can: 'store/add',
+        with: alice.did(),
+        root: { '/': link.toString() },
+      },
+    ],
+    exp: ucan.expiration,
+    prf: [
+      {
+        '/': proof.cid.toString(),
+      },
+    ],
+    s: { '/': { bytes: base64.baseEncode(ucan.signature) } },
+  })
+})
+
+test('delegation.data.toJSON with bytes', async () => {
+  const content = utf8.encode('hello world')
+  const proof = await Delegation.delegate({
+    issuer: alice,
+    audience: bob,
+    capabilities: [
+      {
+        can: 'store/add',
+        with: alice.did(),
+      },
+    ],
+  })
+
+  const ucan = await Delegation.delegate({
+    issuer: bob,
+    audience: mallory,
+    capabilities: [
+      {
+        can: 'store/add',
+        with: alice.did(),
+        root: content,
+      },
+    ],
+    proofs: [proof],
+  })
+
+  assert.deepEqual(toJSON(ucan.data), {
+    v: UCAN.VERSION,
+    iss: bob.did(),
+    aud: mallory.did(),
+    att: [
+      {
+        can: 'store/add',
+        with: alice.did(),
+        root: { '/': { bytes: base64.baseEncode(content) } },
+      },
+    ],
+    exp: ucan.expiration,
+    prf: [
+      {
+        '/': proof.cid.toString(),
+      },
+    ],
+    s: { '/': { bytes: base64.baseEncode(ucan.signature) } },
+  })
+})

--- a/packages/interface/package.json
+++ b/packages/interface/package.json
@@ -23,7 +23,7 @@
     "build": "tsc --build"
   },
   "dependencies": {
-    "@ipld/dag-ucan": "^3.0.1",
+    "@ipld/dag-ucan": "^3.1.1",
     "multiformats": "^10.0.2"
   },
   "devDependencies": {

--- a/packages/interface/src/lib.ts
+++ b/packages/interface/src/lib.ts
@@ -151,7 +151,7 @@ export interface Delegation<C extends Capabilities = Capabilities> {
   issuer: UCAN.Principal
   audience: UCAN.Principal
   capabilities: C
-  expiration?: UCAN.UTCUnixTimestamp
+  expiration: UCAN.UTCUnixTimestamp
   notBefore?: UCAN.UTCUnixTimestamp
 
   nonce?: UCAN.Nonce
@@ -159,6 +159,8 @@ export interface Delegation<C extends Capabilities = Capabilities> {
   facts: Fact[]
   proofs: Proof[]
   iterate(): IterableIterator<Delegation>
+
+  signature: Signature
 }
 
 /**

--- a/packages/principal/package.json
+++ b/packages/principal/package.json
@@ -27,7 +27,7 @@
     "build": "tsc --build"
   },
   "dependencies": {
-    "@ipld/dag-ucan": "^3.0.1",
+    "@ipld/dag-ucan": "^3.1.1",
     "@noble/ed25519": "^1.7.1",
     "@ucanto/interface": "^4.0.3",
     "multiformats": "^10.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,7 +54,7 @@ importers:
     specifiers:
       '@ipld/car': ^5.0.0
       '@ipld/dag-cbor': ^8.0.0
-      '@ipld/dag-ucan': ^3.0.1
+      '@ipld/dag-ucan': ^3.1.1
       '@types/chai': ^4.3.3
       '@types/mocha': ^9.1.0
       '@ucanto/interface': ^4.0.3
@@ -69,7 +69,7 @@ importers:
     dependencies:
       '@ipld/car': 5.0.0
       '@ipld/dag-cbor': 8.0.0
-      '@ipld/dag-ucan': 3.0.1
+      '@ipld/dag-ucan': 3.1.1
       '@ucanto/interface': link:../interface
       multiformats: 10.0.2
     devDependencies:
@@ -85,18 +85,18 @@ importers:
 
   packages/interface:
     specifiers:
-      '@ipld/dag-ucan': ^3.0.1
+      '@ipld/dag-ucan': ^3.1.1
       multiformats: ^10.0.2
       typescript: ^4.8.4
     dependencies:
-      '@ipld/dag-ucan': 3.0.1
+      '@ipld/dag-ucan': 3.1.1
       multiformats: 10.0.2
     devDependencies:
       typescript: 4.8.4
 
   packages/principal:
     specifiers:
-      '@ipld/dag-ucan': ^3.0.1
+      '@ipld/dag-ucan': ^3.1.1
       '@noble/ed25519': ^1.7.1
       '@types/chai': ^4.3.3
       '@types/mocha': ^9.1.0
@@ -110,7 +110,7 @@ importers:
       playwright-test: ^8.1.1
       typescript: ^4.8.4
     dependencies:
-      '@ipld/dag-ucan': 3.0.1
+      '@ipld/dag-ucan': 3.1.1
       '@noble/ed25519': 1.7.1
       '@ucanto/interface': link:../interface
       multiformats: 10.0.2
@@ -474,8 +474,8 @@ packages:
       multiformats: 10.0.2
     dev: false
 
-  /@ipld/dag-ucan/3.0.1:
-    resolution: {integrity: sha512-71YwJeRHxwX3diPXfwiuzhJTjmJSqi8XW/x5Xglp82UqpM5xwtNojB07VhmDXTZXhKi42bZHyQIOLaca/t9IHw==}
+  /@ipld/dag-ucan/3.1.1:
+    resolution: {integrity: sha512-iTIME/QZNGMSXvM8aPDMR9zp6d5orCEAL0BqgAobm9jDt0RV0CLITLWgvxb5MSc0vjRw7GR51Bva1RdZw2qs9w==}
     dependencies:
       '@ipld/dag-cbor': 8.0.0
       '@ipld/dag-json': 9.0.1


### PR DESCRIPTION
Propagates changes form https://github.com/ipld/js-dag-ucan/pull/72 into ucanto and adds some tests to ensure no regressions

Supersedes #173