### PR TITLE
feat: implement dictionary schema

### DIFF
--- a/packages/validator/src/schema/type.ts
+++ b/packages/validator/src/schema/type.ts
@@ -44,6 +44,19 @@ export interface ArraySchema<T, I = unknown> extends Schema<T[], I> {
   element: Reader<T, I>
 }
 
+export interface DictionarySchema<V, K extends string, I = unknown>
+  extends Schema<Dictionary<K, V>, I> {
+  key: Reader<K, string>
+  value: Reader<V, I>
+}
+
+export type Dictionary<
+  K extends string = string,
+  V extends unknown = unknown
+> = {
+  [Key in K]: V
+}
+
 export interface LiteralSchema<
   T extends string | number | boolean | null,
   I = unknown

--- a/packages/validator/test/schema.spec.js
+++ b/packages/validator/test/schema.spec.js
@@ -4,6 +4,7 @@ import fixtures from './schema/fixtures.js'
 
 for (const { input, schema, expect, inputLabel, skip, only } of fixtures()) {
   const unit = skip ? test.skip : only ? test.only : test
+
   unit(`${schema}.read(${inputLabel})`, () => {
     const result = schema.read(input)
 
@@ -12,7 +13,7 @@ for (const { input, schema, expect, inputLabel, skip, only } of fixtures()) {
     } else {
       assert.deepEqual(
         result,
-        // if expcted value is set to undefined use input
+        // if expected value is set to undefined use input
         expect.value === undefined ? input : expect.value
       )
     }
@@ -24,7 +25,7 @@ for (const { input, schema, expect, inputLabel, skip, only } of fixtures()) {
     } else {
       assert.deepEqual(
         schema.from(input),
-        // if expcted value is set to undefined use input
+        // if expected value is set to undefined use input
         expect.value === undefined ? input : expect.value
       )
     }
@@ -62,7 +63,7 @@ test('string startsWith & endsWith', () => {
   assert.equal(hello.read('hello world'), 'hello world')
 })
 
-test('string startsWtih', () => {
+test('string startsWith', () => {
   /** @type {Schema.StringSchema<`hello${string}`>} */
   // @ts-expect-error - catches invalid type
   const bad = Schema.string()
@@ -238,7 +239,7 @@ test('literal("foo").default("bar") throws', () => {
   )
 })
 
-test('default on litral has default', () => {
+test('default on literal has default', () => {
   const schema = Schema.literal('foo').default()
   assert.equal(schema.read(undefined), 'foo')
 })
@@ -260,6 +261,17 @@ test('optional().optional() is noop', () => {
 test('.element of array', () => {
   const schema = Schema.string()
   assert.equal(Schema.array(schema).element, schema)
+})
+
+test('.key & .value of dictionary', () => {
+  const value = Schema.struct({})
+  const key = Schema.enum(['x', 'y'])
+  const schema = Schema.dictionary({ value, key })
+
+  assert.deepEqual(schema.value, value)
+  assert.deepEqual(schema.key, key)
+
+  assert.deepEqual(Schema.dictionary({ value }).key, Schema.string())
 })
 
 test('struct', () => {

--- a/packages/validator/test/schema/fixtures.js
+++ b/packages/validator/test/schema/fixtures.js
@@ -1,5 +1,6 @@
 import { pass, fail, display } from './util.js'
 import * as Schema from '../../src/schema.js'
+import { string, unknown } from '../../src/schema.js'
 
 /**
  * @typedef {import('./util.js').Expect} Expect
@@ -52,6 +53,9 @@ import * as Schema from '../../src/schema.js'
  * point2d?: ExpectGroup
  * ['Red|Green|Blue']?: ExpectGroup
  * xyz?: ExpectGroup
+ * intDict?: ExpectGroup
+ * pointDict?: ExpectGroup
+ * dict: ExpectGroup
  * }} Fixture
  *
  * @param {Partial<Fixture>} source
@@ -128,6 +132,10 @@ export const fixture = ({ in: input, got = input, array, ...expect }) => ({
     any: fail({ got }),
     ...expect.enum,
   },
+  dict: {
+    any: fail({ expect: 'dictionary', got }),
+    ...expect.dict,
+  },
 })
 
 /** @type {Partial<Fixture>[]} */
@@ -182,6 +190,13 @@ export const source = [
     xyz: {
       any: fail.at('"x"', { expect: 'number', got: 'undefined' }),
     },
+    intDict: {
+      any: fail.at('"0"', { expect: 'number', got: '"h"' }),
+    },
+    pointDict: {
+      any: fail.at('0', { expect: 'name|x|y', got: '"0"' }),
+    },
+    dict: { any: pass({ 0: 'h', 1: 'e', 2: 'l', 3: 'l', 4: 'o' }) },
   },
   {
     in: null,
@@ -330,6 +345,9 @@ export const source = [
     },
     xyz: {
       any: fail.at('"x"', { expect: 'number', got: 'undefined' }),
+    },
+    dict: {
+      any: pass(),
     },
   },
   {
@@ -536,6 +554,12 @@ export const source = [
     xyz: {
       any: fail.at('"z"', { expect: 'number', got: 'undefined' }),
     },
+    intDict: {
+      any: fail.at('"name"', { expect: 'number', got: '"Point2d"' }),
+    },
+    dict: {
+      any: pass(),
+    },
   },
   {
     in: { name: 'Point2d', x: 0, z: 0 },
@@ -549,6 +573,15 @@ export const source = [
     xyz: {
       any: fail.at('"y"', { expect: 'number', got: 'undefined' }),
     },
+    intDict: {
+      any: fail.at('"name"', { expect: 'number', got: '"Point2d"' }),
+    },
+    pointDict: {
+      any: fail.at('z', { expect: 'name|x|y', got: '"z"' }),
+    },
+    dict: {
+      any: pass(),
+    },
   },
   {
     in: { name: 'Point2d', x: 0, y: 0.1 },
@@ -560,6 +593,12 @@ export const source = [
       any: fail.at('"y"', { expect: 'integer', got: '0.1' }),
     },
     unknown: {
+      any: pass(),
+    },
+    intDict: {
+      any: fail.at('"name"', { expect: 'number', got: '"Point2d"' }),
+    },
+    dict: {
       any: pass(),
     },
   },
@@ -859,6 +898,24 @@ export const scenarios = fixture => [
       .and(Schema.struct({ y: Schema.integer() }))
       .and(Schema.struct({ z: Schema.integer() })),
     expect: fixture.xyz?.any || fixture.struct.any || fixture.any,
+  },
+  {
+    schema: Schema.dictionary({ value: Schema.integer() }),
+
+    expect: fixture.intDict?.any || fixture.dict?.any || fixture.any,
+  },
+
+  {
+    schema: Schema.dictionary({ value: unknown() }),
+    expect: fixture.dict?.any || fixture.any,
+  },
+
+  {
+    schema: Schema.dictionary({
+      value: unknown(),
+      key: Schema.enum(['name', 'x', 'y']),
+    }),
+    expect: fixture.pointDict?.any || fixture.dict.any || fixture.any,
   },
 ]
 


### PR DESCRIPTION
This pull request adds schema for dictionaries (key value pairs) which are needed for defining schema for fields like

https://github.com/web3-storage/w3protocol/blob/5e6681f4886dc4e50550f58bf795944d51023f71/packages/upload-client/src/types.ts#L45

