### PR TITLE
fix: expose url in channel interface

### DIFF
--- a/packages/interface/src/transport.ts
+++ b/packages/interface/src/transport.ts
@@ -26,6 +26,7 @@ export interface Channel<T extends Record<string, any>> extends Phantom<T> {
   request<I extends Tuple<ServiceInvocation<UCAN.Capability, T>>>(
     request: HTTPRequest<I>
   ): Await<HTTPResponse<InferServiceInvocations<I, T>>>
+  url: URL
 }
 
 export interface RequestEncoder {

--- a/packages/interface/src/transport.ts
+++ b/packages/interface/src/transport.ts
@@ -26,7 +26,7 @@ export interface Channel<T extends Record<string, any>> extends Phantom<T> {
   request<I extends Tuple<ServiceInvocation<UCAN.Capability, T>>>(
     request: HTTPRequest<I>
   ): Await<HTTPResponse<InferServiceInvocations<I, T>>>
-  url: URL
+  url?: URL
 }
 
 export interface RequestEncoder {

--- a/packages/transport/test/https.spec.js
+++ b/packages/transport/test/https.spec.js
@@ -83,3 +83,10 @@ if (typeof globalThis.fetch === 'undefined') {
     }
   })
 }
+
+test('should expose url', async () => {
+    const channel = HTTP.open({
+      url: new URL('https://ucan.xyz/'),
+    })
+    assert.equal(channel.url.toString(), 'https://ucan.xyz/')
+})

--- a/packages/transport/test/https.spec.js
+++ b/packages/transport/test/https.spec.js
@@ -97,5 +97,5 @@ test('should expose url', async () => {
         }
       },
     })
-    assert.equal(channel.url.toString(), 'https://ucan.xyz/')
+    assert.equal(channel.url?.toString(), 'https://ucan.xyz/')
 })

--- a/packages/transport/test/https.spec.js
+++ b/packages/transport/test/https.spec.js
@@ -87,6 +87,15 @@ if (typeof globalThis.fetch === 'undefined') {
 test('should expose url', async () => {
     const channel = HTTP.open({
       url: new URL('https://ucan.xyz/'),
+      fetch: async (url, init) => {
+        return {
+          ok: true,
+          status: 200,
+          url,
+          arrayBuffer: () => UTF8.encode('pong').buffer,
+          headers: new Map([['content-type', 'text/plain']]),
+        }
+      },
     })
     assert.equal(channel.url.toString(), 'https://ucan.xyz/')
 })


### PR DESCRIPTION
Its useful to be able to get the url from the channel directly, in situations where the connection is passed into a function or class and we want to use the connection url has the default for any other communications like WS.

Instead of input url + connection we can just ask the user for connection.

example :  https://github.com/web3-storage/w3protocol/pull/404