### PR TITLE
fix: add @returns to @ucanto/validator Schema.dictionary() to avoid problematic inference when using derives

### DIFF
--- a/packages/validator/src/schema/schema.js
+++ b/packages/validator/src/schema/schema.js
@@ -458,6 +458,7 @@ class Dictionary extends API {
  * @param {object} shape
  * @param {Schema.Reader<V, I>} shape.value
  * @param {Schema.Reader<K, string>} [shape.key]
+ * @returns {Schema.DictionarySchema<V, K, I>}
  */
 export const dictionary = ({ value, key = string() }) =>
   new Dictionary({ value, key })

--- a/packages/validator/test/capability.spec.js
+++ b/packages/validator/test/capability.spec.js
@@ -741,40 +741,6 @@ test('capability amplification', () => {
   )
 })
 
-test('can create derived capability with dict schema in nb', () => {
-  /**
-   * @param {{ with: string }} claim
-   * @param {{ with: string }} proof
-   */
-  const equalWith = (claim, proof) => claim.with === proof.with || new Failure(`claim.with is not proven`);
-  const top = capability({
-    can: '*',
-    with: URI.match({ protocol: 'did:' }),
-    derives: equalWith,
-  });
-  const delegate = top.derive({
-    to: capability({
-      can: 'access/delegate',
-      with: URI,
-      nb: {
-        delegations: Schema.dictionary({
-          value: Schema.Link.match(),
-        }),
-      },
-      derives: (claim, proof) => {
-        // the motivation for this test was that tsc would previously complain at these assignments
-        // and the only workaround was a type assertion https://github.com/web3-storage/w3protocol/pull/420/commits/4f1f2931cecff1d1d1d29e889c4fdfb63ff3b327#diff-e434cc6c1a699df311a0b2faed199a2ff6b6b291d30f95e20b2ea5abfa7da3d9R125
-        /** @type {Schema.Dictionary|undefined} */
-        const claimDelegations = claim.nb.delegations;
-        /** @type {Schema.Dictionary|undefined} */
-        const proofDelegations = proof.nb.delegations;
-        return equalWith(claim, proof);
-      },
-    }),
-    derives: equalWith,
-  })
-})
-
 test('capability or combinator', () => {
   const read = capability({
     can: 'file/read',

--- a/packages/validator/test/capability.spec.js
+++ b/packages/validator/test/capability.spec.js
@@ -741,6 +741,40 @@ test('capability amplification', () => {
   )
 })
 
+test('can create derived capability with dict schema in nb', () => {
+  /**
+   * @param {{ with: string }} claim
+   * @param {{ with: string }} proof
+   */
+  const equalWith = (claim, proof) => claim.with === proof.with || new Failure(`claim.with is not proven`);
+  const top = capability({
+    can: '*',
+    with: URI.match({ protocol: 'did:' }),
+    derives: equalWith,
+  });
+  const delegate = top.derive({
+    to: capability({
+      can: 'access/delegate',
+      with: URI,
+      nb: {
+        delegations: Schema.dictionary({
+          value: Schema.Link.match(),
+        }),
+      },
+      derives: (claim, proof) => {
+        // the motivation for this test was that tsc would previously complain at these assignments
+        // and the only workaround was a type assertion https://github.com/web3-storage/w3protocol/pull/420/commits/4f1f2931cecff1d1d1d29e889c4fdfb63ff3b327#diff-e434cc6c1a699df311a0b2faed199a2ff6b6b291d30f95e20b2ea5abfa7da3d9R125
+        /** @type {Schema.Dictionary|undefined} */
+        const claimDelegations = claim.nb.delegations;
+        /** @type {Schema.Dictionary|undefined} */
+        const proofDelegations = proof.nb.delegations;
+        return equalWith(claim, proof);
+      },
+    }),
+    derives: equalWith,
+  })
+})
+
 test('capability or combinator', () => {
   const read = capability({
     can: 'file/read',

--- a/packages/validator/test/inference.spec.js
+++ b/packages/validator/test/inference.spec.js
@@ -1,7 +1,7 @@
 import * as Voucher from './voucher.js'
 import { test, assert } from './test.js'
 import { alice, bob, mallory, service as w3 } from './fixtures.js'
-import { capability, URI, Link, DID } from '../src/lib.js'
+import { capability, URI, Link, DID, Failure, Schema } from '../src/lib.js'
 import * as API from './types.js'
 
 test('execute capabilty', () =>
@@ -240,5 +240,39 @@ test('infers nb fields in derived capability', () => {
 
     /** @type {string} */
     const _3 = i.capabilities[0].nb.a
+  })
+})
+
+test('can create derived capability with dict schema in nb', () => {
+  /**
+   * @param {{ with: string }} claim
+   * @param {{ with: string }} proof
+   */
+  const equalWith = (claim, proof) => claim.with === proof.with || new Failure(`claim.with is not proven`);
+  const top = capability({
+    can: '*',
+    with: URI.match({ protocol: 'did:' }),
+    derives: equalWith,
+  });
+  const delegate = top.derive({
+    to: capability({
+      can: 'access/delegate',
+      with: URI,
+      nb: {
+        delegations: Schema.dictionary({
+          value: Schema.Link.match(),
+        }),
+      },
+      derives: (claim, proof) => {
+        // the motivation for this test was that tsc would previously complain at these assignments
+        // and the only workaround was a type assertion https://github.com/web3-storage/w3protocol/pull/420/commits/4f1f2931cecff1d1d1d29e889c4fdfb63ff3b327#diff-e434cc6c1a699df311a0b2faed199a2ff6b6b291d30f95e20b2ea5abfa7da3d9R125
+        /** @type {Schema.Dictionary|undefined} */
+        const claimDelegations = claim.nb.delegations;
+        /** @type {Schema.Dictionary|undefined} */
+        const proofDelegations = proof.nb.delegations;
+        return equalWith(claim, proof);
+      },
+    }),
+    derives: equalWith,
   })
 })


### PR DESCRIPTION
Motivation:
* obviate https://github.com/web3-storage/w3protocol/pull/420#discussion_r1095096263