### PR TITLE
add .github/workflows/conventional-commits.yml to check PR titles for conventional commits

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -1,0 +1,22 @@
+name: 'Require Conventional Commits'
+
+on:
+  # `pull_request_target` event runs in the context of the base of the pull request, rather than in the context of the merge commit, as the pull_request event does.
+  # This prevents execution of unsafe code from the head of the pull request that could alter your repository or steal any secrets you use in your workflow.
+  # This event allows your workflow to do things like label or comment on pull requests from forks.
+  # Avoid using this event if you need to build or run code from the pull request.
+  # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Motivation:
* I noticed [with this PR](https://github.com/web3-storage/ucanto/pull/215) that I had omitted conventional commit title and it was allowed, which I'm not used to because we use this workflow in [w3protocol](https://github.com/web3-storage/w3protocol/blob/main/.github/workflows/conventional-commits.yml) and [web3.storage](https://github.com/web3-storage/web3.storage/blob/main/.github/workflows/conventional-commits.yml)

If it doesn't make sense to use here, nbd, just close