### PR TITLE
fix: do not call exports `import` or `export`

### DIFF
--- a/packages/core/src/delegation.js
+++ b/packages/core/src/delegation.js
@@ -229,7 +229,7 @@ export const delegate = async (
  * @returns {IterableIterator<API.Block>}
  */
 
-const exportDAG = function* (root, blocks) {
+export const exportDAG = function* (root, blocks) {
   for (const link of decode(root).proofs) {
     // Check if block is included in this delegation
     const root = /** @type {UCAN.Block} */ (blocks.get(link.toString()))
@@ -296,4 +296,4 @@ const proofs = delegation => {
   return proofs
 }
 
-export { exportDAG as export, importDAG as import, Delegation as View }
+export { Delegation as View }

--- a/packages/core/test/lib.spec.js
+++ b/packages/core/test/lib.spec.js
@@ -340,7 +340,7 @@ test('import delegation', async () => {
     ],
   })
 
-  const replica = Delegation.import(original.export())
+  const replica = Delegation.importDAG(original.export())
   assert.deepEqual(replica, original)
 
   assert.equal(replica.issuer.did(), alice.did())
@@ -355,7 +355,7 @@ test('import delegation', async () => {
 
 test('import empty delegation', async () => {
   assert.throws(
-    () => Delegation.import([]),
+    () => Delegation.importDAG([]),
     /Empty DAG can not be turned into a delegation/
   )
 })
@@ -406,7 +406,7 @@ test('issue chained delegation', async () => {
 
   assert.deepEqual([...invocation.export()], [proof.root, invocation.root])
 
-  assert.deepEqual(Delegation.import(invocation.export()), invocation)
+  assert.deepEqual(Delegation.importDAG(invocation.export()), invocation)
 })
 
 test('delegation with with nested proofs', async () => {
@@ -451,7 +451,7 @@ test('delegation with with nested proofs', async () => {
     'exports all the blocks'
   )
 
-  assert.deepEqual(Delegation.import(invocation.export()), invocation)
+  assert.deepEqual(Delegation.importDAG(invocation.export()), invocation)
 })
 
 test('delegation with external proof', async () => {
@@ -486,7 +486,7 @@ test('delegation with external proof', async () => {
     'exports all the blocks'
   )
 
-  assert.deepEqual(Delegation.import(invocation.export()), invocation)
+  assert.deepEqual(Delegation.importDAG(invocation.export()), invocation)
 })
 
 test('delegation with several proofs', async () => {
@@ -546,7 +546,7 @@ test('delegation with several proofs', async () => {
     'exports all the blocks'
   )
 
-  assert.deepEqual(Delegation.import(invocation.export()), invocation)
+  assert.deepEqual(Delegation.importDAG(invocation.export()), invocation)
 })
 
 test('delegation iterate over proofs', async () => {


### PR DESCRIPTION
Previously this was outputting invalid types:

<img width="1297" alt="Screenshot 2023-02-06 at 15 46 26" src="https://user-images.githubusercontent.com/152863/217017684-835dc858-9270-4e66-9651-4546f689f50d.png">

refs https://github.com/web3-storage/w3up-client/issues/57