### PR TITLE
feat!: Use schema stuff in the capabilities instead of custom parsing

### DIFF
--- a/packages/core/src/invocation.js
+++ b/packages/core/src/invocation.js
@@ -37,9 +37,15 @@ class IssuedInvocation {
 
     /**
      * @readonly
-     * @type {[Capability]}
      */
-    this.capabilities = [capability]
+    this.capabilities =
+      /** @type {[Required<Capability>]} */
+      ([
+        {
+          nb: {},
+          ...capability,
+        },
+      ])
 
     this.expiration = expiration
     this.lifetimeInSeconds = lifetimeInSeconds

--- a/packages/core/src/invocation.js
+++ b/packages/core/src/invocation.js
@@ -37,15 +37,9 @@ class IssuedInvocation {
 
     /**
      * @readonly
+     * @type {[Capability]}
      */
-    this.capabilities =
-      /** @type {[Required<Capability>]} */
-      ([
-        {
-          nb: {},
-          ...capability,
-        },
-      ])
+    this.capabilities = [capability]
 
     this.expiration = expiration
     this.lifetimeInSeconds = lifetimeInSeconds

--- a/packages/interface/src/capability.ts
+++ b/packages/interface/src/capability.ts
@@ -335,10 +335,6 @@ export interface ParsedCapability<
   nb: C
 }
 
-export type InferCaveats<C> = Optionalize<{
-  [K in keyof C]: C[K] extends Reader<infer T, unknown, infer _> ? T : never
-}>
-
 export interface Descriptor<
   A extends Ability,
   R extends URI,

--- a/packages/server/src/api.ts
+++ b/packages/server/src/api.ts
@@ -1,5 +1,5 @@
 import * as API from '@ucanto/interface'
-import { InferCaveats, CanIssue, ParsedCapability } from '@ucanto/interface'
+import { CanIssue, ParsedCapability } from '@ucanto/interface'
 
 export * from '@ucanto/interface'
 
@@ -23,8 +23,8 @@ export interface ProviderContext<
   R extends API.URI = API.URI,
   C extends API.Caveats = API.Caveats
 > {
-  capability: API.ParsedCapability<A, R, API.InferCaveats<C>>
-  invocation: API.Invocation<API.Capability<A, R, API.InferCaveats<C>>>
+  capability: API.ParsedCapability<A, R, C>
+  invocation: API.Invocation<API.Capability<A, R, C>>
 
   context: API.InvocationContext
 }

--- a/packages/server/src/handler.js
+++ b/packages/server/src/handler.js
@@ -6,15 +6,15 @@ import { access } from '@ucanto/validator'
  * @template {API.URI} R
  * @template {API.Caveats} C
  * @template {unknown} U
- * @param {API.CapabilityParser<API.Match<API.ParsedCapability<A, R, API.InferCaveats<C>>>>} capability
- * @param {(input:API.ProviderInput<API.ParsedCapability<A, R, API.InferCaveats<C>>>) => API.Await<U>} handler
- * @returns {API.ServiceMethod<API.Capability<A, R, API.InferCaveats<C>>, Exclude<U, {error:true}>, Exclude<U, Exclude<U, {error:true}>>>}
+ * @param {API.CapabilityParser<API.Match<API.ParsedCapability<A, R, C>>>} capability
+ * @param {(input:API.ProviderInput<API.ParsedCapability<A, R, C>>) => API.Await<U>} handler
+ * @returns {API.ServiceMethod<API.Capability<A, R, C>, Exclude<U, {error:true}>, Exclude<U, Exclude<U, {error:true}>>>}
  */
 
 export const provide =
   (capability, handler) =>
   /**
-   * @param {API.Invocation<API.Capability<A, R, API.InferCaveats<C>>>} invocation
+   * @param {API.Invocation<API.Capability<A, R, C>>} invocation
    * @param {API.InvocationContext} options
    */
   async (invocation, options) => {

--- a/packages/server/test/server.spec.js
+++ b/packages/server/test/server.spec.js
@@ -5,13 +5,14 @@ import * as CBOR from '@ucanto/transport/cbor'
 import { alice, bob, mallory, service as w3 } from './fixtures.js'
 import * as Service from '../../client/test/service.js'
 import { test, assert } from './test.js'
+import { Schema } from '@ucanto/validator'
 
 const storeAdd = Server.capability({
   can: 'store/add',
   with: Server.URI.match({ protocol: 'did:' }),
-  nb: {
+  nb: Schema.struct({
     link: Server.Link.match().optional(),
-  },
+  }),
   derives: (claimed, delegated) => {
     if (claimed.with !== delegated.with) {
       return new Server.Failure(
@@ -34,9 +35,9 @@ const storeAdd = Server.capability({
 const storeRemove = Server.capability({
   can: 'store/remove',
   with: Server.URI.match({ protocol: 'did:' }),
-  nb: {
+  nb: Schema.struct({
     link: Server.Link.match().optional(),
-  },
+  }),
   derives: (claimed, delegated) => {
     if (claimed.with !== delegated.with) {
       return new Server.Failure(

--- a/packages/server/test/service/store.js
+++ b/packages/server/test/service/store.js
@@ -4,13 +4,14 @@ import { provide } from '../../src/handler.js'
 import * as API from './api.js'
 import * as Access from './access.js'
 import { service as issuer } from '../fixtures.js'
+import { Schema } from '@ucanto/validator/src/lib.js'
 
 const addCapability = Server.capability({
   can: 'store/add',
   with: Server.URI.match({ protocol: 'did:' }),
-  nb: {
+  nb: Schema.struct({
     link: Server.Link.match().optional(),
-  },
+  }),
   derives: (claimed, delegated) => {
     if (claimed.with !== delegated.with) {
       return new Server.Failure(
@@ -34,9 +35,9 @@ const addCapability = Server.capability({
 const removeCapability = Server.capability({
   can: 'store/remove',
   with: Server.URI.match({ protocol: 'did:' }),
-  nb: {
+  nb: Schema.struct({
     link: Server.Link.match().optional(),
-  },
+  }),
   derives: (claimed, delegated) => {
     if (claimed.with !== delegated.with) {
       return new Server.Failure(

--- a/packages/validator/src/capability.js
+++ b/packages/validator/src/capability.js
@@ -225,6 +225,8 @@ class Capability extends Unit {
 }
 
 /**
+ * Normalizes capability by removing empty nb field.
+ *
  * @template {API.ParsedCapability} T
  * @param {T} source
  */

--- a/packages/validator/src/capability.js
+++ b/packages/validator/src/capability.js
@@ -7,7 +7,7 @@ import {
   DelegationError as MatchError,
   Failure,
 } from './error.js'
-import { invoke, delegate, DID } from '@ucanto/core'
+import { invoke, delegate } from '@ucanto/core'
 import * as Schema from './schema.js'
 
 /**
@@ -59,7 +59,11 @@ export const and = (...selectors) => new And(selectors)
 /**
  * @template {API.Match} M
  * @template {API.ParsedCapability} T
- * @param {API.DeriveSelector<M, T> & { from: API.MatchSelector<M> }} options
+ * @param {object} source
+ * @param {API.MatchSelector<M>} source.from
+ * @param {API.TheCapabilityParser<API.DirectMatch<T>>} source.to
+ * @param {API.Derives<T, API.InferDeriveProof<M['value']>>} source.derives
+ 
  * @returns {API.TheCapabilityParser<API.DerivedMatch<T, M>>}
  */
 export const derive = ({ from, to, derives }) => new Derive(from, to, derives)
@@ -87,7 +91,9 @@ class View {
 
   /**
    * @template {API.ParsedCapability} U
-   * @param {API.DeriveSelector<M, U>} options
+   * @param {object} source
+   * @param {API.TheCapabilityParser<API.DirectMatch<U>>} source.to
+   * @param {API.Derives<U, API.InferDeriveProof<M['value']>>} source.derives
    * @returns {API.TheCapabilityParser<API.DerivedMatch<U, M>>}
    */
   derive({ derives, to }) {
@@ -355,7 +361,7 @@ class Derive extends Unit {
   /**
    * @param {API.MatchSelector<M>} from
    * @param {API.TheCapabilityParser<API.DirectMatch<T>>} to
-   * @param {API.Derives<API.ToDeriveClaim<T>, API.ToDeriveProof<M['value']>>} derives
+   * @param {API.Derives<T, API.InferDeriveProof<M['value']>>} derives
    */
   constructor(from, to, derives) {
     super()
@@ -499,7 +505,7 @@ class DerivedMatch {
   /**
    * @param {API.DirectMatch<T>} selected
    * @param {API.MatchSelector<M>} from
-   * @param {API.Derives<API.ToDeriveClaim<T>, API.ToDeriveProof<M['value']>>} derives
+   * @param {API.Derives<T, API.InferDeriveProof<M['value']>>} derives
    */
   constructor(selected, from, derives) {
     this.selected = selected

--- a/packages/validator/src/capability.js
+++ b/packages/validator/src/capability.js
@@ -7,16 +7,38 @@ import {
   DelegationError as MatchError,
   Failure,
 } from './error.js'
-import { invoke, delegate } from '@ucanto/core'
+import { invoke, delegate, DID } from '@ucanto/core'
+import * as Schema from './schema.js'
+
+/**
+ * @template {API.Ability} A
+ * @template {API.URI} R
+ * @template {API.Caveats} C
+ * @typedef {{
+ * can: A
+ * with: API.Reader<R, API.Resource, API.Failure>
+ * nb?: Schema.MapRepresentation<C, unknown>
+ * derives?: (claim: {can:A, with: R, nb: C}, proof:{can:A, with:R, nb:C}) => API.Result<true, API.Failure>
+ * }} Descriptor
+ */
 
 /**
  * @template {API.Ability} A
  * @template {API.URI} R
  * @template {API.Caveats} [C={}]
- * @param {API.Descriptor<A, R, C>} descriptor
+ * @param {Descriptor<A, R, C>} descriptor
+ 
  * @returns {API.TheCapabilityParser<API.CapabilityMatch<A, R, C>>}
  */
-export const capability = descriptor => new Capability(descriptor)
+export const capability = ({
+  derives = defaultDerives,
+  nb = defaultNBSchema,
+  ...etc
+}) => new Capability({ derives, nb, ...etc })
+
+const defaultNBSchema =
+  /** @type {Schema.MapRepresentation<any>} */
+  (Schema.struct({}))
 
 /**
  * @template {API.Match} M
@@ -102,25 +124,30 @@ class Unit extends View {
  * @template {API.Ability} A
  * @template {API.URI} R
  * @template {API.Caveats} C
- * @implements {API.TheCapabilityParser<API.DirectMatch<API.ParsedCapability<A, R, API.InferCaveats<C>>>>}
- * @extends {Unit<API.DirectMatch<API.ParsedCapability<A, R, API.InferCaveats<C>>>>}
+ * @implements {API.TheCapabilityParser<API.DirectMatch<API.ParsedCapability<A, R, C>>>}
+ * @extends {Unit<API.DirectMatch<API.ParsedCapability<A, R, C>>>}
  */
 class Capability extends Unit {
   /**
-   * @param {API.Descriptor<A, R, C>} descriptor
+   * @param {Required<Descriptor<A, R, C>>} descriptor
    */
   constructor(descriptor) {
     super()
-    this.descriptor = { derives, ...descriptor }
+    this.descriptor = descriptor
+    this.schema = Schema.struct({
+      can: Schema.literal(descriptor.can),
+      with: descriptor.with,
+      nb: descriptor.nb,
+    })
   }
 
   /**
-   * @param {API.InferCreateOptions<R, API.InferCaveats<C>>} options
+   * @param {API.InferCreateOptions<R, C>} options
    */
   create(options) {
     const { descriptor, can } = this
     const decoders = descriptor.nb
-    const data = /** @type {API.InferCaveats<C>} */ (options.nb || {})
+    const data = /** @type {C} */ (options.nb || {})
 
     const resource = descriptor.with.read(options.with)
     if (resource.error) {
@@ -129,51 +156,36 @@ class Capability extends Unit {
       })
     }
 
-    const capabality =
-      /** @type {API.ParsedCapability<A, R, API.InferCaveats<C>>} */
-      ({ can, with: resource })
-
-    for (const [name, decoder] of Object.entries(decoders || {})) {
-      const key = /** @type {keyof data & string} */ (name)
-      const value = decoder.read(data[key])
-      if (value?.error) {
-        throw Object.assign(
-          new Error(`Invalid 'nb.${key}' - ${value.message}`),
-          { cause: value }
-        )
-      } else if (value !== undefined) {
-        const nb =
-          capabality.nb ||
-          (capabality.nb = /** @type {API.InferCaveats<C>} */ ({}))
-
-        const key = /** @type {keyof nb} */ (name)
-        nb[key] = /** @type {typeof nb[key]} */ (value)
-      }
+    const nb = descriptor.nb.read(data)
+    if (nb.error) {
+      throw Object.assign(new Error(`Invalid 'nb' - ${nb.message}`), {
+        cause: nb,
+      })
     }
 
-    return capabality
+    return createCapability({ can, with: resource, nb })
   }
 
   /**
-   * @param {API.InferInvokeOptions<R, API.InferCaveats<C>>} options
+   * @param {API.InferInvokeOptions<R, C>} options
    */
   invoke({ with: with_, nb, ...options }) {
     return invoke({
       ...options,
       capability: this.create(
-        /** @type {API.InferCreateOptions<R, API.InferCaveats<C>>} */
+        /** @type {API.InferCreateOptions<R, C>} */
         ({ with: with_, nb })
       ),
     })
   }
 
   /**
-   * @param {API.InferDelegationOptions<R, API.InferCaveats<C>>} options
+   * @param {API.InferDelegationOptions<R, C>} options
+   * @returns {Promise<API.Delegation<[API.InferDelegatedCapability<API.ParsedCapability<A, R, C>>]>>}
    */
-  async delegate({ with: with_, nb, ...options }) {
+  async delegate({ nb: input = {}, with: with_, ...options }) {
     const { descriptor, can } = this
     const readers = descriptor.nb
-    const data = /** @type {API.InferCaveats<C>} */ (nb || {})
 
     const resource = descriptor.with.read(with_)
     if (resource.error) {
@@ -182,32 +194,15 @@ class Capability extends Unit {
       })
     }
 
-    const capabality =
-      /** @type {API.ParsedCapability<A, R, API.InferCaveats<C>>} */
-      ({ can, with: resource })
-
-    for (const [name, reader] of Object.entries(readers || {})) {
-      const key = /** @type {keyof data & string} */ (name)
-      const source = data[key]
-      // omit undefined fields in the delegation
-      const value = source === undefined ? source : reader.read(data[key])
-      if (value?.error) {
-        throw Object.assign(
-          new Error(`Invalid 'nb.${key}' - ${value.message}`),
-          { cause: value }
-        )
-      } else if (value !== undefined) {
-        const nb =
-          capabality.nb ||
-          (capabality.nb = /** @type {API.InferCaveats<C>} */ ({}))
-
-        const key = /** @type {keyof nb} */ (name)
-        nb[key] = /** @type {typeof nb[key]} */ (value)
-      }
+    const nb = descriptor.nb.partial().read(input)
+    if (nb.error) {
+      throw Object.assign(new Error(`Invalid 'nb' - ${nb.message}`), {
+        cause: nb,
+      })
     }
 
-    return await delegate({
-      capabilities: [capabality],
+    return delegate({
+      capabilities: [createCapability({ can, with: resource, nb })],
       ...options,
     })
   }
@@ -218,15 +213,38 @@ class Capability extends Unit {
 
   /**
    * @param {API.Source} source
-   * @returns {API.MatchResult<API.DirectMatch<API.ParsedCapability<A, R, API.InferCaveats<C>>>>}
+   * @returns {API.MatchResult<API.DirectMatch<API.ParsedCapability<A, R, C>>>}
    */
   match(source) {
-    const result = parseCapability(this, source)
+    const result = parseCapability(this.descriptor, source)
     return result.error ? result : new Match(source, result, this.descriptor)
   }
   toString() {
     return JSON.stringify({ can: this.descriptor.can })
   }
+}
+
+/**
+ * @template {API.ParsedCapability} T
+ * @param {T} source
+ */
+
+const createCapability = ({ can, with: with_, nb }) =>
+  /** @type {API.InferCapability<T>} */ ({
+    can,
+    with: with_,
+    ...(isEmpty(nb) ? {} : { nb }),
+  })
+
+/**
+ * @param {object} object
+ * @returns {object is {}}
+ */
+const isEmpty = object => {
+  for (const _ in object) {
+    return false
+  }
+  return true
 }
 
 /**
@@ -386,18 +404,18 @@ class Derive extends Unit {
  * @template {API.Ability} A
  * @template {API.URI} R
  * @template {API.Caveats} C
- * @implements {API.DirectMatch<API.ParsedCapability<A, R, API.InferCaveats<C>>>}
+ * @implements {API.DirectMatch<API.ParsedCapability<A, R, C>>}
  */
 class Match {
   /**
    * @param {API.Source} source
-   * @param {API.ParsedCapability<A, R, API.InferCaveats<C>>} value
-   * @param {API.Descriptor<A, R, C>} descriptor
+   * @param {API.ParsedCapability<A, R, C>} value
+   * @param {Required<Descriptor<A, R, C>>} descriptor
    */
   constructor(source, value, descriptor) {
     this.source = [source]
     this.value = value
-    this.descriptor = { derives, ...descriptor }
+    this.descriptor = descriptor
   }
   get can() {
     return this.value.can
@@ -413,7 +431,7 @@ class Match {
 
   /**
    * @param {API.CanIssue} context
-   * @returns {API.DirectMatch<API.ParsedCapability<A, R, API.InferCaveats<C>>>|null}
+   * @returns {API.DirectMatch<API.ParsedCapability<A, R, C>>|null}
    */
   prune(context) {
     if (context.canIssue(this.value, this.source[0].delegation.issuer.did())) {
@@ -425,14 +443,14 @@ class Match {
 
   /**
    * @param {API.Source[]} capabilities
-   * @returns {API.Select<API.DirectMatch<API.ParsedCapability<A, R, API.InferCaveats<C>>>>}
+   * @returns {API.Select<API.DirectMatch<API.ParsedCapability<A, R, C>>>}
    */
   select(capabilities) {
     const unknown = []
     const errors = []
     const matches = []
     for (const capability of capabilities) {
-      const result = resolveCapability(this, this.value, capability)
+      const result = resolveCapability(this.descriptor, this.value, capability)
       if (!result.error) {
         const claim = this.descriptor.derives(this.value, result)
         if (claim.error) {
@@ -703,37 +721,29 @@ const resolveResource = (source, uri, fallback) => {
  * @template {API.Ability} A
  * @template {API.URI} R
  * @template {API.Caveats} C
- * @param {{descriptor: API.Descriptor<A, R, C>}} parser
+ * @param {Required<Descriptor<A, R, C>>} descriptor
  * @param {API.Source} source
- * @returns {API.Result<API.ParsedCapability<A, R, API.InferCaveats<C>>, API.InvalidCapability>}
+ * @returns {API.Result<API.ParsedCapability<A, R, C>, API.InvalidCapability>}
  */
-const parseCapability = (parser, source) => {
-  const { can, with: withReader, nb: readers } = parser.descriptor
+const parseCapability = (descriptor, source) => {
   const { delegation } = source
-  const capability = /** @type {API.Capability<A, R, API.InferCaveats<C>>} */ (
-    source.capability
-  )
+  const capability = /** @type {API.Capability<A, R, C>} */ (source.capability)
 
-  if (can !== capability.can) {
+  if (descriptor.can !== capability.can) {
     return new UnknownCapability(capability)
   }
 
-  const uri = withReader.read(capability.with)
+  const uri = descriptor.with.read(capability.with)
   if (uri.error) {
     return new MalformedCapability(capability, uri)
   }
 
-  const nb = parseNB(capability, readers)
+  const nb = descriptor.nb.read(capability.nb || {})
   if (nb.error) {
-    return nb
+    return new MalformedCapability(capability, nb)
   }
 
-  return new CapabilityView(
-    can,
-    uri,
-    /** @type {API.InferCaveats<C>} */ (nb),
-    delegation
-  )
+  return new CapabilityView(descriptor.can, uri, nb, delegation)
 }
 
 /**
@@ -747,17 +757,13 @@ const parseCapability = (parser, source) => {
  * @template {API.Ability} A
  * @template {API.URI} R
  * @template {API.Caveats} C
- * @param {{descriptor: API.Descriptor<A, R, C>}} parser
- * @param {API.ParsedCapability<A, R, API.InferCaveats<C>>} claimed
+ * @param {Required<Descriptor<A, R, C>>} descriptor
+ * @param {API.ParsedCapability<A, R, C>} claimed
  * @param {API.Source} source
- * @returns {API.Result<API.ParsedCapability<A, R, API.InferCaveats<C>>, API.InvalidCapability>}
+ * @returns {API.Result<API.ParsedCapability<A, R, C>, API.InvalidCapability>}
  */
 
-const resolveCapability = (
-  { descriptor: schema },
-  claimed,
-  { capability, delegation }
-) => {
+const resolveCapability = (descriptor, claimed, { capability, delegation }) => {
   const can = resolveAbility(capability.can, claimed.can, null)
   if (can == null) {
     return new UnknownCapability(capability)
@@ -768,59 +774,21 @@ const resolveCapability = (
     claimed.with,
     capability.with
   )
-  const uri = schema.with.read(resource)
+  const uri = descriptor.with.read(resource)
   if (uri.error) {
     return new MalformedCapability(capability, uri)
   }
 
-  const nb = parseNB(capability, schema.nb, { ...claimed.nb })
+  const nb = descriptor.nb.read({
+    ...claimed.nb,
+    ...capability.nb,
+  })
+
   if (nb.error) {
-    return nb
+    return new MalformedCapability(capability, nb)
   }
 
-  return new CapabilityView(
-    can,
-    uri,
-    /** @type {API.InferCaveats<C>} */ (nb),
-    delegation
-  )
-}
-
-/**
- * Parses `nb` field of the provided `capability` with given set of `readers`.
- * If `implicit` argument is provided it will treat all fields as optional and
- * fall back to an implicit field. If `implicit` is not provided it will fail
- * if any non-optional field is missing.
- *
- * @template {API.Ability} A
- * @template {API.URI} R
- * @template {API.Caveats} C
- * @param {API.Capability<A, R>} capability
- * @param {C|undefined} readers
- * @param {Partial<API.InferCaveats<C>>} [implicit]
- * @returns {API.Result<API.InferCaveats<C>, API.MalformedCapability>}
- */
-const parseNB = (capability, readers, implicit) => {
-  const nb = /** @type {API.InferCaveats<C>} */ ({})
-  if (readers) {
-    /** @type {Partial<API.InferCaveats<C>>} */
-    const caveats = capability.nb || {}
-    for (const [name, reader] of entries(readers)) {
-      const key = /** @type {keyof caveats & keyof nb & string} */ (name)
-      if (key in caveats || !implicit) {
-        const result = reader.read(caveats[key])
-        if (result?.error) {
-          return new MalformedCapability(capability, result)
-        } else if (result != null) {
-          nb[key] = /** @type {any} */ (result)
-        }
-      } else if (key in implicit) {
-        nb[key] = /** @type {nb[key]} */ (implicit[key])
-      }
-    }
-  }
-
-  return nb
+  return new CapabilityView(can, uri, nb, delegation)
 }
 
 /**
@@ -832,7 +800,7 @@ class CapabilityView {
   /**
    * @param {A} can
    * @param {R} with_
-   * @param {API.InferCaveats<C>} nb
+   * @param {C} nb
    * @param {API.Delegation} delegation
    */
   constructor(can, with_, nb, delegation) {
@@ -913,7 +881,7 @@ const selectGroup = (self, capabilities) => {
  * @param {U} delegated
  * @return {API.Result<true, API.Failure>}
  */
-const derives = (claimed, delegated) => {
+const defaultDerives = (claimed, delegated) => {
   if (delegated.with.endsWith('*')) {
     if (!claimed.with.startsWith(delegated.with.slice(0, -1))) {
       return new Failure(

--- a/packages/validator/src/lib.js
+++ b/packages/validator/src/lib.js
@@ -130,11 +130,13 @@ const resolveSources = async ({ delegation }, config) => {
           // otherwise create source objects for it's capabilities, so we could
           // track which proof in which capability the are from.
           for (const capability of proof.capabilities) {
-            sources.push({
-              capability,
-              delegation: proof,
-              index,
-            })
+            sources.push(
+              /** @type {API.Source} */ ({
+                capability,
+                delegation: proof,
+                index,
+              })
+            )
           }
         }
       }
@@ -160,9 +162,9 @@ const isSelfIssued = (capability, issuer) => capability.with === issuer
  * @template {API.URI} R
  * @template {R} URI
  * @template {API.Caveats} C
- * @param {API.Invocation<API.Capability<A, URI, API.InferCaveats<C>>>} invocation
- * @param {API.ValidationOptions<API.ParsedCapability<A, R, API.InferCaveats<C>>>} options
- * @returns {Promise<API.Result<Authorization<API.ParsedCapability<A, R, API.InferCaveats<C>>>, API.Unauthorized>>}
+ * @param {API.Invocation<API.Capability<A, URI, C>>} invocation
+ * @param {API.ValidationOptions<API.ParsedCapability<A, R, C>>} options
+ * @returns {Promise<API.Result<Authorization<API.ParsedCapability<A, R, C>>, API.Unauthorized>>}
  */
 export const access = async (invocation, { capability, ...config }) =>
   claim(capability, [invocation], config)
@@ -176,10 +178,10 @@ export const access = async (invocation, { capability, ...config }) =>
  * @template {API.Ability} A
  * @template {API.URI} R
  * @template {API.Caveats} C
- * @param {API.CapabilityParser<API.Match<API.ParsedCapability<A, R, API.InferCaveats<C>>>>} capability
+ * @param {API.CapabilityParser<API.Match<API.ParsedCapability<A, R, C>>>} capability
  * @param {API.Proof[]} proofs
  * @param {API.ClaimOptions} config
- * @returns {Promise<API.Result<Authorization<API.ParsedCapability<A, R, API.InferCaveats<C>>>, API.Unauthorized>>}
+ * @returns {Promise<API.Result<Authorization<API.ParsedCapability<A, R, C>>, API.Unauthorized>>}
  */
 export const claim = async (
   capability,
@@ -210,11 +212,13 @@ export const claim = async (
 
     if (!delegation.error) {
       for (const [index, capability] of delegation.capabilities.entries()) {
-        sources.push({
-          capability,
-          delegation,
-          index,
-        })
+        sources.push(
+          /** @type {API.Source} */ ({
+            capability,
+            delegation,
+            index,
+          })
+        )
       }
     } else {
       invalidProofs.push(delegation)
@@ -518,7 +522,7 @@ const resolveDIDFromProofs = async (did, delegation, config) => {
     to: capability({
       with: Schema.literal(config.authority.did()),
       can: './update',
-      nb: { key: DID.match({ method: 'key' }) },
+      nb: Schema.struct({ key: DID.match({ method: 'key' }) }),
     }),
     derives: equalWith,
   })

--- a/packages/validator/src/schema/schema.js
+++ b/packages/validator/src/schema/schema.js
@@ -158,6 +158,10 @@ class Never extends API {
   read(input) {
     return typeError({ expect: 'never', actual: input })
   }
+
+  partial() {
+    return this
+  }
 }
 
 /**
@@ -177,6 +181,12 @@ class Unknown extends API {
    */
   read(input) {
     return /** @type {Schema.ReadResult<unknown>}*/ (input)
+  }
+  /**
+   * @returns {Schema.Schema<Partial<unknown>, I>}
+   */
+  partial() {
+    return /** @type {Schema.Schema<Partial<unknown>, I>} */ (this)
   }
   toString() {
     return 'unknown()'
@@ -435,7 +445,10 @@ class Dictionary extends API {
         return memberError({ at: k, cause: valueResult })
       }
 
-      dict[keyResult] = valueResult
+      // skip undefined because they mess up CBOR and are generally useless.
+      if (valueResult !== undefined) {
+        dict[keyResult] = valueResult
+      }
     }
 
     return dict
@@ -445,6 +458,14 @@ class Dictionary extends API {
   }
   get value() {
     return this.settings.value
+  }
+
+  partial() {
+    const { key, value } = this.settings
+    return new Dictionary({
+      key,
+      value: optional(value),
+    })
   }
   toString() {
     return `dictionary(${this.settings})`
@@ -1069,6 +1090,17 @@ class Struct extends API {
     }
 
     return struct
+  }
+
+  /**
+   * @returns {Schema.MapRepresentation<Partial<Schema.InferStruct<U>>> & Schema.StructSchema}
+   */
+  partial() {
+    return new Struct(
+      Object.fromEntries(
+        Object.entries(this.shape).map(([key, value]) => [key, optional(value)])
+      )
+    )
   }
 
   /** @type {U} */

--- a/packages/validator/src/schema/schema.js
+++ b/packages/validator/src/schema/schema.js
@@ -158,10 +158,6 @@ class Never extends API {
   read(input) {
     return typeError({ expect: 'never', actual: input })
   }
-
-  partial() {
-    return this
-  }
 }
 
 /**
@@ -181,12 +177,6 @@ class Unknown extends API {
    */
   read(input) {
     return /** @type {Schema.ReadResult<unknown>}*/ (input)
-  }
-  /**
-   * @returns {Schema.Schema<Partial<unknown>, I>}
-   */
-  partial() {
-    return /** @type {Schema.Schema<Partial<unknown>, I>} */ (this)
   }
   toString() {
     return 'unknown()'

--- a/packages/validator/test/capability-access.spec.js
+++ b/packages/validator/test/capability-access.spec.js
@@ -14,10 +14,10 @@ const capabilities = {
     add: capability({
       can: 'store/add',
       with: DID,
-      nb: {
+      nb: Schema.struct({
         link: Link,
         size: Schema.integer().optional(),
-      },
+      }),
       derives: (claim, proof) => {
         if (claim.with !== proof.with) {
           return new Failure('with field does not match')
@@ -38,9 +38,9 @@ const capabilities = {
     ping: capability({
       can: 'dev/ping',
       with: DID,
-      nb: {
+      nb: Schema.struct({
         message: Schema.string(),
-      },
+      }),
     }),
   },
 }

--- a/packages/validator/test/capability.spec.js
+++ b/packages/validator/test/capability.spec.js
@@ -1907,6 +1907,8 @@ test('derived capability match & select', () => {
       b.with === a.with ? true : new Failure(`with don't match`),
   })
 
+  assert.equal(AA.can, 'derive/a')
+
   const proof = {
     issuer: alice,
     fake: { thing: 'thing' },

--- a/packages/validator/test/capability.spec.js
+++ b/packages/validator/test/capability.spec.js
@@ -797,9 +797,9 @@ test('parse with nb', () => {
   const storeAdd = capability({
     can: 'store/add',
     with: URI.match({ protocol: 'did:' }),
-    nb: {
+    nb: Schema.struct({
       link: Link.match().optional(),
-    },
+    }),
     derives: (claimed, delegated) => {
       if (claimed.with !== delegated.with) {
         return new Failure(
@@ -842,7 +842,10 @@ test('parse with nb', () => {
               nb: { link: 5 },
             },
             cause: {
-              message: 'Expected link to be a CID instead of 5',
+              name: 'FieldError',
+              cause: {
+                message: 'Expected link to be a CID instead of 5',
+              },
             },
           },
         ],
@@ -1201,9 +1204,9 @@ test('capability create with nb', () => {
   const echo = capability({
     can: 'test/echo',
     with: URI.match({ protocol: 'did:' }),
-    nb: {
+    nb: Schema.struct({
       message: URI.match({ protocol: 'data:' }),
-    },
+    }),
   })
 
   assert.throws(() => {
@@ -1222,7 +1225,7 @@ test('capability create with nb', () => {
     echo.create({
       with: alice.did(),
     })
-  }, /Invalid 'nb.message' - Expected URI but got undefined/)
+  }, /Expected URI but got undefined/)
 
   assert.throws(() => {
     echo.create({
@@ -1232,7 +1235,7 @@ test('capability create with nb', () => {
         message: 'echo:foo',
       },
     })
-  }, /Invalid 'nb.message' - Expected data: URI instead got echo:foo/)
+  }, /Expected data: URI instead got echo:foo/)
 
   assert.deepEqual(
     echo.create({ with: alice.did(), nb: { message: 'data:hello' } }),
@@ -1421,9 +1424,9 @@ test('invoke capability (with nb)', () => {
   const echo = capability({
     can: 'test/echo',
     with: URI.match({ protocol: 'did:' }),
-    nb: {
+    nb: Schema.struct({
       message: URI.match({ protocol: 'data:' }),
-    },
+    }),
   })
 
   assert.throws(() => {
@@ -1445,7 +1448,7 @@ test('invoke capability (with nb)', () => {
       audience: w3,
       with: alice.did(),
     })
-  }, /Invalid 'nb.message' - Expected URI but got undefined/)
+  }, /Expected URI but got undefined/)
 
   assert.throws(() => {
     echo.create({
@@ -1455,7 +1458,7 @@ test('invoke capability (with nb)', () => {
         message: 'echo:foo',
       },
     })
-  }, /Invalid 'nb.message' - Expected data: URI instead got echo:foo/)
+  }, /Expected data: URI instead got echo:foo/)
 
   assert.deepEqual(
     echo.invoke({
@@ -1503,10 +1506,10 @@ test('capability with optional caveats', async () => {
   const Echo = capability({
     can: 'test/echo',
     with: URI.match({ protocol: 'did:' }),
-    nb: {
+    nb: Schema.struct({
       message: URI.match({ protocol: 'data:' }),
       meta: Link.match().optional(),
-    },
+    }),
   })
 
   const echo = await Echo.invoke({
@@ -1619,17 +1622,17 @@ test('.and(...).match', () => {
   const A = capability({
     can: 'test/ab',
     with: URI,
-    nb: {
+    nb: Schema.struct({
       a: Schema.Text,
-    },
+    }),
   })
 
   const B = capability({
     can: 'test/ab',
     with: URI,
-    nb: {
+    nb: Schema.struct({
       b: Schema.Text,
-    },
+    }),
   })
 
   const AB = A.and(B)
@@ -1731,17 +1734,17 @@ test('and with diff nb', () => {
   const A = capability({
     can: 'test/me',
     with: URI,
-    nb: {
+    nb: Schema.struct({
       a: Schema.Text,
-    },
+    }),
   })
 
   const B = capability({
     can: 'test/me',
     with: URI,
-    nb: {
+    nb: Schema.struct({
       b: Schema.Text,
-    },
+    }),
   })
 
   const AB = A.and(B)
@@ -1792,8 +1795,6 @@ test('derived capability DSL', () => {
     derives: (b, a) =>
       b.with === a.with ? true : new Failure(`with don't match`),
   })
-
-  assert.equal(AA.can, 'derive/a')
 
   assert.deepEqual(
     AA.create({
@@ -1855,9 +1856,9 @@ test('capability match', () => {
   const echo = capability({
     can: 'test/echo',
     with: URI.match({ protocol: 'did:' }),
-    nb: {
+    nb: Schema.struct({
       message: URI.match({ protocol: 'data:' }),
-    },
+    }),
   })
 
   const m3 = echo.match(
@@ -2021,9 +2022,9 @@ test('default derive with nb', () => {
   const Profile = capability({
     can: 'profile/set',
     with: Schema.URI.match({ protocol: 'file:' }),
-    nb: {
+    nb: Schema.struct({
       mime: Schema.Text,
-    },
+    }),
   })
 
   const pic = Profile.match(

--- a/packages/validator/test/inference.spec.js
+++ b/packages/validator/test/inference.spec.js
@@ -136,11 +136,8 @@ test('infers nb fields in derived capability', () => {
     }),
     derives: (claim, proof) => {
       /** @type {string} */
-      // @ts-expect-error - may be undefined
+      /** @type {API.URI<"data:">} */
       const _1 = claim.nb.bar
-
-      /** @type {API.URI<"data:">|undefined} */
-      const _2 = claim.nb.bar
 
       /** @type {string} */
       // @ts-expect-error - may be undefined
@@ -180,11 +177,7 @@ test('infers nb fields in derived capability', () => {
       }),
     }),
     derives: (claim, [a, b]) => {
-      /** @type {string} */
-      // @ts-expect-error - may be undefined
-      const _1 = claim.nb.c
-
-      /** @type {API.URI<"data:">|undefined} */
+      /** @type {API.URI<"data:">} */
       const _2 = claim.nb.c
 
       /** @type {string} */

--- a/packages/validator/test/inference.spec.js
+++ b/packages/validator/test/inference.spec.js
@@ -4,7 +4,7 @@ import { alice, bob, mallory, service as w3 } from './fixtures.js'
 import { capability, URI, Link, DID, Failure, Schema } from '../src/lib.js'
 import * as API from './types.js'
 
-test('execute capabilty', () =>
+test('execute capability', () =>
   /**
    * @param {API.ConnectionView<API.Service>} connection
    */
@@ -98,19 +98,17 @@ test('infers nb fields optional', () => {
   capability({
     can: 'test/nb',
     with: DID.match({ method: 'key' }),
-    nb: {
+    nb: Schema.struct({
       msg: URI.match({ protocol: 'data:' }),
-    },
+    }),
     derives: (claim, proof) => {
       /** @type {string} */
-      // @ts-expect-error - may be undefined
       const _1 = claim.nb.msg
 
       /** @type {API.URI<"data:">|undefined} */
       const _2 = claim.nb.msg
 
       /** @type {string} */
-      // @ts-expect-error - may be undefined
       const _3 = proof.nb.msg
 
       /** @type {API.URI<"data:">|undefined} */
@@ -125,16 +123,16 @@ test('infers nb fields in derived capability', () => {
   capability({
     can: 'test/base',
     with: DID.match({ method: 'key' }),
-    nb: {
+    nb: Schema.struct({
       msg: URI.match({ protocol: 'data:' }),
-    },
+    }),
   }).derive({
     to: capability({
       can: 'test/derived',
       with: DID.match({ method: 'key' }),
-      nb: {
+      nb: Schema.struct({
         bar: URI.match({ protocol: 'data:' }),
-      },
+      }),
     }),
     derives: (claim, proof) => {
       /** @type {string} */
@@ -160,26 +158,26 @@ test('infers nb fields in derived capability', () => {
   const A = capability({
     can: 'test/a',
     with: DID.match({ method: 'key' }),
-    nb: {
+    nb: Schema.struct({
       a: URI.match({ protocol: 'data:' }),
-    },
+    }),
   })
 
   const B = capability({
     can: 'test/b',
     with: DID.match({ method: 'key' }),
-    nb: {
+    nb: Schema.struct({
       b: URI.match({ protocol: 'data:' }),
-    },
+    }),
   })
 
   A.and(B).derive({
     to: capability({
       can: 'test/c',
       with: DID.match({ method: 'key' }),
-      nb: {
+      nb: Schema.struct({
         c: URI.match({ protocol: 'data:' }),
-      },
+      }),
     }),
     derives: (claim, [a, b]) => {
       /** @type {string} */
@@ -211,9 +209,9 @@ test('infers nb fields in derived capability', () => {
     const A = capability({
       can: 'test/a',
       with: DID.match({ method: 'key' }),
-      nb: {
+      nb: Schema.struct({
         a: URI.match({ protocol: 'data:' }),
-      },
+      }),
     })
 
     const a = await A.delegate({
@@ -248,29 +246,30 @@ test('can create derived capability with dict schema in nb', () => {
    * @param {{ with: string }} claim
    * @param {{ with: string }} proof
    */
-  const equalWith = (claim, proof) => claim.with === proof.with || new Failure(`claim.with is not proven`);
+  const equalWith = (claim, proof) =>
+    claim.with === proof.with || new Failure(`claim.with is not proven`)
   const top = capability({
     can: '*',
     with: URI.match({ protocol: 'did:' }),
     derives: equalWith,
-  });
+  })
   const delegate = top.derive({
     to: capability({
       can: 'access/delegate',
       with: URI,
-      nb: {
+      nb: Schema.struct({
         delegations: Schema.dictionary({
           value: Schema.Link.match(),
         }),
-      },
+      }),
       derives: (claim, proof) => {
         // the motivation for this test was that tsc would previously complain at these assignments
         // and the only workaround was a type assertion https://github.com/web3-storage/w3protocol/pull/420/commits/4f1f2931cecff1d1d1d29e889c4fdfb63ff3b327#diff-e434cc6c1a699df311a0b2faed199a2ff6b6b291d30f95e20b2ea5abfa7da3d9R125
         /** @type {Schema.Dictionary|undefined} */
-        const claimDelegations = claim.nb.delegations;
+        const claimDelegations = claim.nb.delegations
         /** @type {Schema.Dictionary|undefined} */
-        const proofDelegations = proof.nb.delegations;
-        return equalWith(claim, proof);
+        const proofDelegations = proof.nb.delegations
+        return equalWith(claim, proof)
       },
     }),
     derives: equalWith,

--- a/packages/validator/test/lib.spec.js
+++ b/packages/validator/test/lib.spec.js
@@ -1,5 +1,5 @@
 import { test, assert } from './test.js'
-import { access, claim } from '../src/lib.js'
+import { access, claim, Schema } from '../src/lib.js'
 import { capability, URI, Link } from '../src/lib.js'
 import { Failure } from '../src/error.js'
 import { Verifier } from '@ucanto/principal'
@@ -12,10 +12,10 @@ import { UnavailableProof } from '../src/error.js'
 const storeAdd = capability({
   can: 'store/add',
   with: URI.match({ protocol: 'did:' }),
-  nb: {
+  nb: Schema.struct({
     link: Link,
     origin: Link.optional(),
-  },
+  }),
   derives: (claimed, delegated) => {
     if (claimed.with !== delegated.with) {
       return new Failure(

--- a/packages/validator/test/mailto.spec.js
+++ b/packages/validator/test/mailto.spec.js
@@ -17,9 +17,9 @@ const claim = capability({
 const update = capability({
   can: './update',
   with: DID,
-  nb: {
+  nb: Schema.struct({
     key: DID.match({ method: 'key' }),
-  },
+  }),
 })
 
 test('validate mailto', async () => {

--- a/packages/validator/test/map-schema.spec.js
+++ b/packages/validator/test/map-schema.spec.js
@@ -1,0 +1,47 @@
+import * as Schema from '../src/schema.js'
+import { test, assert } from './test.js'
+
+test('.partial on structs', () => {
+  const Point = Schema.struct({
+    x: Schema.integer(),
+    y: Schema.integer(),
+  })
+
+  const PartialPoint = Point.partial()
+
+  assert.deepEqual(PartialPoint.shape, {
+    x: Schema.integer().optional(),
+    y: Schema.integer().optional(),
+  })
+
+  assert.deepEqual(PartialPoint.from({}), {})
+  assert.deepEqual(PartialPoint.from({ x: 1 }), { x: 1 })
+  assert.deepEqual(PartialPoint.from({ x: 1, y: 2 }), { x: 1, y: 2 })
+  assert.deepEqual(PartialPoint.from({ y: 2 }), { y: 2 })
+  assert.deepEqual(PartialPoint.from({ x: undefined }), {})
+  assert.deepEqual(PartialPoint.from({ x: undefined, y: 2 }), { y: 2 })
+
+  assert.throws(
+    () =>
+      // @ts-expect-error - should complain about no argument
+      Point.create(),
+    /invalid field/
+  )
+
+  assert.deepEqual(PartialPoint.create(), {})
+})
+
+test('.partial on dicts', () => {
+  const Ints = Schema.dictionary({ value: Schema.integer() })
+  const IntsMaybe = Ints.partial()
+
+  assert.equal(IntsMaybe.key, Ints.key)
+  assert.deepEqual(IntsMaybe.value, Schema.integer().optional())
+
+  assert.deepEqual(IntsMaybe.from({}), {})
+  assert.deepEqual(IntsMaybe.from({ x: 1 }), { x: 1 })
+  assert.deepEqual(IntsMaybe.from({ x: 1, y: 2 }), { x: 1, y: 2 })
+  assert.deepEqual(IntsMaybe.from({ y: 2 }), { y: 2 })
+  assert.deepEqual(IntsMaybe.from({ x: undefined }), {})
+  assert.deepEqual(IntsMaybe.from({ x: undefined, y: 2 }), { y: 2 })
+})

--- a/packages/validator/test/util.js
+++ b/packages/validator/test/util.js
@@ -47,8 +47,8 @@ export const canDelegateLink = (child, parent) => {
  * Checks that `with` on claimed capability is the same as `with`
  * in delegated capability. Note this will ignore `can` field.
  *
- * @param {API.ParsedCapability} child
- * @param {API.ParsedCapability} parent
+ * @param {{can: API.Ability, with: string}} child
+ * @param {{can: API.Ability, with: string}} parent
  */
 export function equalWith(child, parent) {
   return (

--- a/packages/validator/test/voucher.js
+++ b/packages/validator/test/voucher.js
@@ -1,5 +1,5 @@
 import { equalWith, canDelegateURI, canDelegateLink, fail } from './util.js'
-import { capability, URI, Text, Link, DID } from '../src/lib.js'
+import { capability, URI, Text, Link, DID, Schema } from '../src/lib.js'
 
 export const Voucher = capability({
   can: 'voucher/*',
@@ -10,11 +10,11 @@ export const Claim = Voucher.derive({
   to: capability({
     can: 'voucher/claim',
     with: DID.match({ method: 'key' }),
-    nb: {
+    nb: Schema.struct({
       product: Link,
       identity: URI.match({ protocol: 'mailto:' }),
       service: DID,
-    },
+    }),
     derives: (child, parent) => {
       return (
         fail(equalWith(child, parent)) ||
@@ -31,9 +31,9 @@ export const Claim = Voucher.derive({
 export const Redeem = capability({
   can: 'voucher/redeem',
   with: URI.match({ protocol: 'did:' }),
-  nb: {
+  nb: Schema.struct({
     product: Text,
     identity: Text,
     account: URI.match({ protocol: 'did:' }),
-  },
+  }),
 })


### PR DESCRIPTION
`capability` logic came before the `Schema` did we have not got around to integrating schema fully into `capability` we even end up with bunch of code that duplicated logic that is in schema.

Consequently it became impossible to use Schema.struct or Schema.dict on the `nb` field. This PR updates `capability` to just use `Schema`. 