### PR TITLE
proposal: add a bag of string-keyed key/value pairs to InvocationContext

### DIFF
--- a/packages/interface/src/lib.ts
+++ b/packages/interface/src/lib.ts
@@ -288,7 +288,12 @@ export interface InvocationContext extends CanIssue {
   my?: (issuer: DID) => Capability[]
   resolve?: (proof: UCANLink) => Await<Result<Delegation, UnavailableProof>>
 
-  principal: PrincipalParser
+  principal: PrincipalParser,
+  /**
+   * A bag of key/value pairs. Can be used, for instance, to make HTTP headers available
+   * to invocation handlers.
+   */
+  metadata?: Record<string, any>
 }
 
 export type ResolveServiceMethod<


### PR DESCRIPTION
As part of https://github.com/web3-storage/w3protocol/issues/347 I'm looking into making location information from Cloudflare HTTP headers available to the invocation handler that generates space registration emails (ie, https://github.com/web3-storage/w3protocol/blob/main/packages/access-api/src/service/voucher-claim.js#L45) so that we can tell users where in the world a space registration request was initiated. This is a common pattern in web services and is intended to help the user make better choices about which verification requests to approve.

To do this, we need some way of making HTTP headers available to invocation handlers. I'd like to do this without tying the InvocationContext too tightly to HTTP, and the simplest thing I can think of is adding a bag of string-keyed key/value pairs named `metadata` to InvocationContext.

Very open to other approaches here - this is intended to be the starting point for a conversation.

One note worth bringing up for clarity - this opens the door to invocation handlers doing all sorts of things with information from the HTTP headers, some of which could conceivably be a violation of a user's privacy. It may be worth implementing some sort of allow-list mechanism rather than just passing all HTTP headers through as I'm doing in this PR. I'm not entirely sure where this configuration would live, so am looking for thoughts and feedback.