### PR TITLE
fix: drop error boolean on server errors

### DIFF
--- a/packages/interface/src/lib.ts
+++ b/packages/interface/src/lib.ts
@@ -765,7 +765,6 @@ export type ExecuteInvocation<
 export interface Failure extends Error {}
 
 export interface HandlerNotFound extends RangeError {
-  error: true
   capability: Capability
   name: 'HandlerNotFound'
 }

--- a/packages/server/src/server.js
+++ b/packages/server/src/server.js
@@ -169,8 +169,6 @@ export class HandlerNotFound extends RangeError {
    */
   constructor(capability) {
     super()
-    /** @type {true} */
-    this.error = true
     this.capability = capability
   }
   /** @type {'HandlerNotFound'} */
@@ -183,7 +181,6 @@ export class HandlerNotFound extends RangeError {
   toJSON() {
     return {
       name: this.name,
-      error: this.error,
       capability: {
         can: this.capability.can,
         with: this.capability.with,
@@ -203,8 +200,6 @@ class HandlerExecutionError extends Failure {
     super()
     this.capability = capability
     this.cause = cause
-    /** @type { true } */
-    this.error = true
   }
 
   /** @type {'HandlerExecutionError'} */
@@ -217,7 +212,6 @@ class HandlerExecutionError extends Failure {
   toJSON() {
     return {
       name: this.name,
-      error: this.error,
       capability: {
         can: this.capability.can,
         with: this.capability.with,
@@ -241,7 +235,6 @@ class InvocationCapabilityError extends Error {
   constructor(caps) {
     super()
     /** @type {true} */
-    this.error = true
     this.caps = caps
   }
   get name() {
@@ -253,7 +246,6 @@ class InvocationCapabilityError extends Error {
   toJSON() {
     return {
       name: this.name,
-      error: this.error,
       message: this.message,
       capabilities: this.caps,
     }


### PR DESCRIPTION
Now that we wrap errors with `error` property and error object within it, `error: true` is redundant and should be removed