### PR TITLE
feat: add Schema.bytes

### DIFF
--- a/packages/core/src/schema/schema.js
+++ b/packages/core/src/schema/schema.js
@@ -921,6 +921,28 @@ const anyString = new AnyString()
 export const string = () => anyString
 
 /**
+ * @template [I=unknown]
+ * @extends {API<Uint8Array, I, void>}
+ */
+class BytesSchema extends API {
+  /**
+   * @param {I} input
+   * @returns {Schema.ReadResult<Uint8Array>}
+   */
+  readWith(input) {
+    if (input instanceof Uint8Array) {
+      return { ok: input }
+    } else {
+      return typeError({ expect: 'Uint8Array', actual: input })
+    }
+  }
+}
+
+/** @type {Schema.Schema<Uint8Array, unknown>} */
+export const Bytes = new BytesSchema()
+export const bytes = () => Bytes
+
+/**
  * @template {string} Prefix
  * @template {string} Body
  * @extends {API<Body & `${Prefix}${Body}`, Body, Prefix>}
@@ -1380,7 +1402,13 @@ const displayTypeName = value => {
     case 'undefined':
       return String(value)
     case 'object':
-      return value === null ? 'null' : Array.isArray(value) ? 'array' : 'object'
+      return value === null
+        ? 'null'
+        : Array.isArray(value)
+        ? 'array'
+        : Symbol.toStringTag in /** @type {object} */ (value)
+        ? value[Symbol.toStringTag]
+        : 'object'
     default:
       return type
   }

--- a/packages/core/test/schema.spec.js
+++ b/packages/core/test/schema.spec.js
@@ -657,3 +657,24 @@ test('record defaults', () => {
     end: { x: 1, y: 3 },
   })
 })
+
+test('bytes schema', () => {
+  const schema = Schema.bytes()
+  matchError(schema.read(undefined), /expect.* Uint8Array .* got undefined/is)
+
+  const bytes = new Uint8Array([1, 2, 3])
+
+  assert.equal(schema.read(bytes).ok, bytes, 'returns same bytes back')
+
+  matchError(
+    schema.read(bytes.buffer),
+    /expect.* Uint8Array .* got ArrayBuffer/is
+  )
+
+  matchError(
+    schema.read(new Int8Array(bytes.buffer)),
+    /expect.* Uint8Array .* got Int8Array/is
+  )
+
+  matchError(schema.read([...bytes]), /expect.* Uint8Array .* got array/is)
+})


### PR DESCRIPTION
In the IPFS Thing workshop we needed schema for bytes which I have injected into observable. This change ports it into ucanto.