### PR TITLE
fix!: attach ipld view instead of single block

### DIFF
--- a/packages/core/src/invocation.js
+++ b/packages/core/src/invocation.js
@@ -87,16 +87,17 @@ class IssuedInvocation {
   }
 
   /**
-   * Attach a block to the invocation DAG so it would be included in the
-   * block iterator.
+   * Attach block from IPLD View to the invocation DAG so it would be included
+   * in the block iterator.
    * ⚠️ You should only attach blocks that are referenced from the `capabilities`
-   * or `facts`, if that is not the case you probably should reconsider.
-   * ⚠️ Once a delegation is de-serialized the attached blocks will not be re-attached.
+   * or `facts`.
    *
-   * @param {API.Block} block
+   * @param {API.IPLDView} view
    */
-  attach(block) {
-    this.attachedBlocks.set(`${block.cid}`, block)
+  attach(view) {
+    for (const block of view.iterateIPLDBlocks()) {
+      this.attachedBlocks.set(`${block.cid}`, block)
+    }
   }
 
   delegate() {

--- a/packages/core/test/delegation.spec.js
+++ b/packages/core/test/delegation.spec.js
@@ -306,7 +306,10 @@ test('delegation.attach block in capabiliy', async () => {
     ],
   })
 
-  ucan.attach(block)
+  ucan.attach({
+    iterateIPLDBlocks: () => [block].values(),
+    root: block
+  })
 
   const delegationBlocks = []
   for (const b of ucan.iterateIPLDBlocks()) {
@@ -334,7 +337,10 @@ test('delegation.attach block in facts', async () => {
     ]
   })
 
-  ucan.attach(block)
+  ucan.attach({
+    iterateIPLDBlocks: () => [block].values(),
+    root: block
+  })
 
   const delegationBlocks = []
   for (const b of ucan.iterateIPLDBlocks()) {
@@ -357,5 +363,8 @@ test('delegation.attach fails to attach block with not attached link', async () 
   })
 
   const block = await getBlock({ test: 'inlineBlock' })
-  assert.throws(() => ucan.attach(block))
+  assert.throws(() => ucan.attach({
+    iterateIPLDBlocks: () => [block].values(),
+    root: block
+  }))
 })

--- a/packages/core/test/invocation.spec.js
+++ b/packages/core/test/invocation.spec.js
@@ -47,7 +47,10 @@ test('encode invocation with attached block in capability nb', async () => {
     },
     proofs: [],
   })
-  add.attach(block)
+  add.attach({
+    iterateIPLDBlocks: () => [block].values(),
+    root: block
+  })
 
   /** @type {import('@ucanto/interface').BlockStore<unknown>} */
   const blockStore = new Map()

--- a/packages/interface/src/lib.ts
+++ b/packages/interface/src/lib.ts
@@ -246,7 +246,7 @@ export interface Delegation<C extends Capabilities = Capabilities>
   toJSON(): DelegationJSON<this>
   delegate(): Await<Delegation<C>>
 
-  attach(block: Block): void
+  attach(block: IPLDView): void
 }
 
 /**
@@ -549,7 +549,7 @@ export interface IssuedInvocation<C extends Capability = Capability>
   readonly proofs: Proof[]
 
   delegate(): Await<Delegation<[C]>>
-  attach(block: Block): void
+  attach(block: IPLDView): void
 }
 
 export type ServiceInvocation<


### PR DESCRIPTION
Attach view instead of single block per https://github.com/web3-storage/ucanto/pull/298#discussion_r1181285696

BREAKING CHANGE: delegation.attach() and invocation.attach() now receive IPLDView instead of Block