### PR TITLE
docs: add delegation and invocation attach method comments to interface

### DIFF
--- a/packages/core/src/invocation.js
+++ b/packages/core/src/invocation.js
@@ -87,12 +87,6 @@ class IssuedInvocation {
   }
 
   /**
-   * Attach a block to the invocation DAG so it would be included in the
-   * block iterator.
-   * ⚠️ You should only attach blocks that are referenced from the `capabilities`
-   * or `facts`, if that is not the case you probably should reconsider.
-   * ⚠️ Once a delegation is de-serialized the attached blocks will not be re-attached.
-   *
    * @param {API.Block} block
    */
   attach(block) {

--- a/packages/interface/src/lib.ts
+++ b/packages/interface/src/lib.ts
@@ -248,6 +248,12 @@ export interface Delegation<C extends Capabilities = Capabilities>
 
   archive(): Await<Result<Uint8Array, Error>>
 
+  /**
+   * Attach a block to the delegation DAG so it would be included in the
+   * block iterator.
+   * ⚠️ You can only attach blocks that are referenced from the `capabilities`
+   * or `facts`.
+   */
   attach(block: Block): void
 }
 
@@ -551,6 +557,14 @@ export interface IssuedInvocation<C extends Capability = Capability>
   readonly proofs: Proof[]
 
   delegate(): Await<Delegation<[C]>>
+
+  /**
+   * Attach a block to the invocation DAG so it would be included in the
+   * block iterator.
+   * ⚠️ You should only attach blocks that are referenced from the `capabilities`
+   * or `facts`, if that is not the case you probably should reconsider.
+   * ⚠️ Once a delegation is de-serialized the attached blocks will not be re-attached.
+   */
   attach(block: Block): void
 }
 


### PR DESCRIPTION
* Removed from unexported class.
* Added to `@ucanto/interface` so that consumers can read them.