### PR TITLE
feat!: update `@ucanto/interface` dependencies

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -29,7 +29,7 @@
     "build": "tsc --build"
   },
   "dependencies": {
-    "@ucanto/interface": "workspace:^",
+    "@ucanto/interface": "workspace:^8",
     "@ucanto/core": "workspace:^"
   },
   "devDependencies": {

--- a/packages/principal/package.json
+++ b/packages/principal/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@ipld/dag-ucan": "^3.3.2",
     "@noble/ed25519": "^1.7.3",
-    "@ucanto/interface": "workspace:^",
+    "@ucanto/interface": "workspace:^8",
     "multiformats": "^11.0.0",
     "one-webcrypto": "^1.0.3"
   },

--- a/packages/transport/package.json
+++ b/packages/transport/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@ucanto/core": "workspace:^",
-    "@ucanto/interface": "workspace:^"
+    "@ucanto/interface": "workspace:^8"
   },
   "devDependencies": {
     "@types/chai": "^4.3.3",

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -30,7 +30,7 @@
     "@ipld/car": "^5.1.0",
     "@ipld/dag-cbor": "^9.0.0",
     "@ucanto/core": "workspace:^",
-    "@ucanto/interface": "workspace:^",
+    "@ucanto/interface": "workspace:^8",
     "multiformats": "^11.0.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,7 +20,7 @@ importers:
         specifier: workspace:^
         version: link:../core
       '@ucanto/interface':
-        specifier: workspace:^
+        specifier: workspace:^8
         version: link:../interface
     devDependencies:
       '@types/chai':
@@ -128,7 +128,7 @@ importers:
         specifier: ^1.7.3
         version: 1.7.3
       '@ucanto/interface':
-        specifier: workspace:^
+        specifier: workspace:^8
         version: link:../interface
       multiformats:
         specifier: ^11.0.0
@@ -226,7 +226,7 @@ importers:
         specifier: workspace:^
         version: link:../core
       '@ucanto/interface':
-        specifier: workspace:^
+        specifier: workspace:^8
         version: link:../interface
     devDependencies:
       '@types/chai':
@@ -272,7 +272,7 @@ importers:
         specifier: workspace:^
         version: link:../core
       '@ucanto/interface':
-        specifier: workspace:^
+        specifier: workspace:^8
         version: link:../interface
       multiformats:
         specifier: ^11.0.0
@@ -357,7 +357,7 @@ packages:
       '@babel/traverse': 7.20.12
       '@babel/types': 7.20.7
       convert-source-map: 1.9.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.0
@@ -509,7 +509,7 @@ packages:
       '@babel/helper-split-export-declaration': 7.18.6
       '@babel/parser': 7.20.7
       '@babel/types': 7.20.7
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -1321,6 +1321,18 @@ packages:
     engines: {node: '>= 6'}
     dev: true
 
+  /debug@4.3.4:
+    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.2
+    dev: true
+
   /debug@4.3.4(supports-color@8.1.1):
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
     engines: {node: '>=6.0'}
@@ -2128,7 +2140,7 @@ packages:
     resolution: {integrity: sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==}
     engines: {node: '>=10'}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       istanbul-lib-coverage: 3.2.0
       source-map: 0.6.1
     transitivePeerDependencies:


### PR DESCRIPTION
`@ucanto/interface` had breaking changes, but because code in dependant libraries didn't change, release-please didn't cut new releases.

by manually specifying that the `@ucanto/interface` dependency must by 8 or above, this should trigger a release-please flow to release `@ucanto/interface@8`-compatible releases of these four libs.