### PR TITLE
fix: ensure `@ucanto/server` depends on v8 deps

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -28,17 +28,17 @@
     "build": "tsc --build"
   },
   "dependencies": {
-    "@ucanto/core": "workspace:^",
-    "@ucanto/interface": "workspace:^",
-    "@ucanto/validator": "workspace:^"
+    "@ucanto/core": "workspace:^8",
+    "@ucanto/interface": "workspace:^8",
+    "@ucanto/validator": "workspace:^8"
   },
   "devDependencies": {
     "@types/chai": "^4.3.3",
     "@types/chai-subset": "^1.3.3",
     "@types/mocha": "^10.0.1",
-    "@ucanto/client": "workspace:^",
-    "@ucanto/principal": "workspace:^",
-    "@ucanto/transport": "workspace:^",
+    "@ucanto/client": "workspace:^8",
+    "@ucanto/principal": "workspace:^8",
+    "@ucanto/transport": "workspace:^8",
     "@web-std/fetch": "^4.1.0",
     "@web-std/file": "^3.0.2",
     "c8": "^7.13.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,13 +165,13 @@ importers:
   packages/server:
     dependencies:
       '@ucanto/core':
-        specifier: workspace:^
+        specifier: workspace:^8
         version: link:../core
       '@ucanto/interface':
-        specifier: workspace:^
+        specifier: workspace:^8
         version: link:../interface
       '@ucanto/validator':
-        specifier: workspace:^
+        specifier: workspace:^8
         version: link:../validator
     devDependencies:
       '@types/chai':
@@ -184,13 +184,13 @@ importers:
         specifier: ^10.0.1
         version: 10.0.1
       '@ucanto/client':
-        specifier: workspace:^
+        specifier: workspace:^8
         version: link:../client
       '@ucanto/principal':
-        specifier: workspace:^
+        specifier: workspace:^8
         version: link:../principal
       '@ucanto/transport':
-        specifier: workspace:^
+        specifier: workspace:^8
         version: link:../transport
       '@web-std/fetch':
         specifier: ^4.1.0


### PR DESCRIPTION
because of the way release-please releases deps, `@ucanto/server@8.0.0` depends on `@ucanto/validator@7` which gives downstream deps nightmares

bumping these deps like this will trigger a new `@ucanto/server` release which will only depend on `ucanto@8` deps