### PR TITLE
fix: cbor prepare encode wrongly identifying circular structure

### DIFF
--- a/packages/core/src/cbor.js
+++ b/packages/core/src/cbor.js
@@ -62,7 +62,7 @@ const prepare = (data, seen) => {
     const object = {}
     for (const [key, value] of Object.entries(data)) {
       if (value !== undefined && typeof value !== 'symbol') {
-        object[key] = prepare(value, seen)
+        object[key] = prepare(value, new Set(seen))
       }
     }
     return object

--- a/packages/core/test/cbor.spec.js
+++ b/packages/core/test/cbor.spec.js
@@ -65,6 +65,16 @@ test('encode / decode', async () => {
     assert.throws(() => transcode(nested), /Can not encode circular structure/)
   })
 
+  test('encodes object with same object properties', () => {
+    const o = {}
+    const data = {
+      a: o,
+      b: o
+    }
+
+    assert.doesNotThrow(() => transcode(data))
+  })
+
   test('cids', async () => {
     const hello = await write({ hello: 'world' })
 


### PR DESCRIPTION
Failing on:

```js
const obj = {}
CBOR.encode({
  a: obj,
  b: obj
})
```