### PR TITLE
fix: do not use frozen object for headers

### DIFF
--- a/packages/transport/src/car/response.js
+++ b/packages/transport/src/car/response.js
@@ -34,7 +34,7 @@ export const encode = (message, options) => {
   })
 
   return {
-    headers: HEADERS,
+    headers: { ...HEADERS },
     body,
   }
 }


### PR DESCRIPTION
Sometimes the headers are mutated by the environment the code is run in...

resolves https://github.com/web3-storage/w3up/issues/1254