### PR TITLE
feat: add Receipt#toJSON

### DIFF
--- a/packages/core/src/receipt.js
+++ b/packages/core/src/receipt.js
@@ -28,6 +28,25 @@ export const view = ({ root, blocks }, fallback) => {
 }
 
 /**
+ * @template {{}} Ok
+ * @template {{}} Error
+ * @template {API.Invocation} Ran
+ * @template {API.SigAlg} [SigAlg=API.SigAlg]
+ * @param {Receipt<Ok, Error, Ran, SigAlg>} r
+ */
+function toJSON(r) {
+  return {
+    ran: r.ran,
+    out: r.out,
+    fx: r.fx,
+    meta: r.meta,
+    issuer: r.issuer,
+    proofs: r.proofs,
+    signature: r.signature,
+  }
+}
+
+/**
  * Represents a UCAN invocation receipt view over some block store e.g. in
  * memory CAR. It incrementally decodes proofs, ran invocation etc. on access
  * which reduces overhead but potentially defers errors if references blocks
@@ -59,6 +78,10 @@ class Receipt {
     this._signature = signature
     this._proofs = proofs
     this._issuer = issuer
+  }
+
+  toJSON() {
+    return toJSON(this)
   }
 
   /**

--- a/packages/core/src/receipt.js
+++ b/packages/core/src/receipt.js
@@ -33,6 +33,7 @@ export const view = ({ root, blocks }, fallback) => {
  * @template {API.Invocation} Ran
  * @template {API.SigAlg} [SigAlg=API.SigAlg]
  * @param {Receipt<Ok, Error, Ran, SigAlg>} r
+ * @returns {unknown}
  */
 function toJSON(r) {
   return {


### PR DESCRIPTION
Motivation:
* start conversation about whether this is a good idea
* rationale:
  * ucanto Receipts have many getters that are 'views' into other objects (e.g. they might lazily decode on demand). Invocations/Delegations can be like this too.
  * when these objects get JSON stringified, the JSON representation only shows the underlying data, not the lazily decoded properties from getters. But frequently I am logging the object in order to see the derived/lazy properties, not just the underlying one.
* workaround: https://github.com/web3-storage/migrate-to-w3up/pull/3/files#r1473527173
