### PR TITLE
feat: http transport includes more information in error message when encountering non-ok http response

### DIFF
--- a/packages/transport/src/http.js
+++ b/packages/transport/src/http.js
@@ -65,7 +65,7 @@ class Channel {
 
     const buffer = response.ok
       ? await response.arrayBuffer()
-      : HTTPError.throw('HTTP Request failed', response)
+      : HTTPError.throw(`HTTP Request failed. ${this.method} ${this.url.href} → ${response.status}`, response)
 
     return {
       headers: response.headers.entries


### PR DESCRIPTION
Motivation:
* there are some errors in sentry that just show up as "HTTP Request Failed", even though their root causes are probably all quite distinct. Not every caller of something that might use a ucanto client is ready to catch an `HTTPError` and inspect the `.response` property to determine what happened, and in general this may be hard because the response stream can usually only be read one time and yet that's the best way to determine the error description from the service that returned a non-ok http response. So the motivation for this change is so that our other software, when this error goes uncaught, has more distinct error messages about what's going on so they 1) share more about what's going wrong and 2) therefore also get grouped by that information in error trackers like sentry