### PR TITLE
fix: revert "feat: http transport includes more information in error message when encountering non-ok http response"

### DIFF
--- a/packages/transport/src/http.js
+++ b/packages/transport/src/http.js
@@ -65,7 +65,7 @@ class Channel {
 
     const buffer = response.ok
       ? await response.arrayBuffer()
-      : HTTPError.throw(`HTTP Request failed. ${this.method} ${this.url.href} → ${response.status}`, response)
+      : HTTPError.throw('HTTP Request failed', response)
 
     return {
       headers: response.headers.entries


### PR DESCRIPTION
Reverts web3-storage/ucanto#340