### PR TITLE
feat: http transport includes more information in error message when encountering non-ok http response

### DIFF
--- a/packages/transport/src/http.js
+++ b/packages/transport/src/http.js
@@ -65,7 +65,7 @@ class Channel {
 
     const buffer = response.ok
       ? await response.arrayBuffer()
-      : HTTPError.throw('HTTP Request failed', response)
+      : HTTPError.throw(`HTTP Request failed. ${this.method} ${this.url.href} → ${response.status}`, response)
 
     return {
       headers: response.headers.entries


### PR DESCRIPTION
This is a duplicate of the already-approved-by @Gozala https://github.com/web3-storage/ucanto/pull/340

I messed up last time in how I clicked merge, and it made it hard to deploy via release-please. So this PR I will be more careful with.