### PR TITLE
feat!: resolve multiple verifiers

### DIFF
--- a/packages/interface/src/lib.ts
+++ b/packages/interface/src/lib.ts
@@ -1092,8 +1092,8 @@ export interface PrincipalParser {
  */
 export interface PrincipalResolver {
   resolveDIDKey?: (
-    did: UCAN.DID
-  ) => Await<Result<DIDKey, DIDKeyResolutionError>>
+    did: UCAN.DID,
+  ) => Await<Result<DIDKey[], DIDKeyResolutionError>>
 }
 
 /**

--- a/packages/server/test/server.spec.js
+++ b/packages/server/test/server.spec.js
@@ -351,7 +351,7 @@ test('did:web principal resolve', async () => {
     codec: CAR.inbound,
     id: w3,
     resolveDIDKey: did => did === account.did()
-      ? Server.ok(bob.did())
+      ? Server.ok([bob.did()])
       : Server.error(new DIDResolutionError(did)),
     validateAuthorization: () => ({ ok: {} }),
   })

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -22,6 +22,7 @@
     "test:web": "playwright-test test/**/*.spec.js --cov && nyc report",
     "test:node": "c8 --check-coverage --branches 100 --functions 100 --lines 100 mocha test/**/*.spec.js",
     "test": "c8 --check-coverage --branches 100 --functions 100 --lines 100 mocha --bail test/**/*.spec.js",
+    "test:only": "c8 --check-coverage --branches 100 --functions 100 --lines 100 mocha --bail",
     "coverage": "c8 --reporter=html mocha test/**/*.spec.js",
     "check": "tsc --build",
     "build": "tsc --build"


### PR DESCRIPTION
### Support Multiple Verifiers in DID Resolution

Added support for multiple verifiers in the DID Key resolution process. Previously, the `config.resolveDIDKey` method would resolve a single verifier, which is fine. However, if we decide to resolve `did:key` from a `did:plc` document, we need to resolve all verifiers traversed the returned list to find one that successfully verifies the signature.

## Main Changes
- Modified the `verifyAuthorization` function in `packages/validator/src/lib.js` to handle multiple verifiers returned by `resolveDIDKey`
- Added support for iterating through multiple verifiers and attempting verification with each one
- Added new test cases to verify the behavior with multiple verifiers

Related: https://github.com/storacha/project-tracking/issues/463