### PR TITLE
feat(principal)!: webcrypto ed25519 signer support for non-extractable agent keys

### DIFF
--- a/packages/principal/package.json
+++ b/packages/principal/package.json
@@ -29,7 +29,6 @@
   "dependencies": {
     "@ipld/dag-ucan": "^3.4.5",
     "@noble/curves": "^1.2.0",
-    "@noble/ed25519": "^1.7.3",
     "@noble/hashes": "^1.3.2",
     "@ucanto/interface": "workspace:^",
     "multiformats": "^13.3.1",

--- a/packages/principal/src/ed25519/type.ts
+++ b/packages/principal/src/ed25519/type.ts
@@ -4,6 +4,7 @@ import {
   MulticodecCode,
   ByteView,
   DIDKey,
+  KeyArchive,
 } from '@ucanto/interface'
 import * as Signature from '@ipld/dag-ucan/signature'
 
@@ -44,7 +45,7 @@ export interface EdSigner extends SignerKey<SigAlg> {
    */
   toArchive(): {
     id: DIDKey
-    keys: { [Key: DIDKey]: ByteView<SignerKey<SigAlg> & CryptoKey> }
+    keys: { [Key: DIDKey]: KeyArchive<SigAlg> }
   }
 }
 

--- a/packages/principal/test/ed25519.spec.js
+++ b/packages/principal/test/ed25519.spec.js
@@ -2,6 +2,7 @@ import { ed25519, ed25519 as Lib } from '../src/lib.js'
 import { assert } from 'chai'
 import { sha256 } from 'multiformats/hashes/sha2'
 import { varint } from 'multiformats'
+import { webcrypto } from 'one-webcrypto'
 
 describe('signing principal', () => {
   const { Signer } = Lib
@@ -45,8 +46,19 @@ describe('signing principal', () => {
     assert.equal(signer.did(), verifier.did())
   })
 
+  it('generate non extractable by default', async () => {
+    const signer = await Lib.generate()
+    const { id, keys } = signer.toArchive()
+    const key = /** @type {CryptoKey} */ (keys[id])
+
+    assert.equal(key.type, 'private')
+    assert.deepEqual(Object(key.algorithm), { name: 'Ed25519' })
+    assert.equal(key.extractable, false)
+    assert.deepEqual(key.usages, ['sign'])
+  })
+
   it('derive', async () => {
-    const original = await Lib.generate()
+    const original = await Lib.generate({ extractable: true })
     // @ts-expect-error - secret is not defined by interface
     const derived = await Lib.derive(original.secret)
 
@@ -57,7 +69,7 @@ describe('signing principal', () => {
 
   it('derive throws on bad input', async () => {
     // @ts-expect-error - secret is not defined by interface
-    const { secret } = await Lib.generate()
+    const { secret } = await Lib.generate({ extractable: true })
     try {
       await Lib.derive(secret.subarray(1))
       assert.fail('Expected to throw')
@@ -67,22 +79,26 @@ describe('signing principal', () => {
   })
 
   it('SigningPrincipal.decode', async () => {
-    const signer = await Lib.generate()
+    const signer = await Lib.generate({ extractable: true })
     const bytes = Signer.encode(signer)
     const { id, keys } = signer.toArchive()
+    const key = keys[id]
+    if (!(key instanceof Uint8Array)) {
+      return assert.fail('Expected archive key to be Uint8Array')
+    }
 
-    assert.deepEqual(Signer.decode(keys[id]), signer)
+    assert.deepEqual(Signer.decode(key), signer)
 
-    const invalid = new Uint8Array(keys[id])
+    const invalid = new Uint8Array(key)
     varint.encodeTo(4, invalid, 0)
     assert.throws(() => Signer.decode(invalid), /must be a multiformat with/)
 
     assert.throws(
-      () => Signer.decode(keys[id].slice(0, 32)),
+      () => Signer.decode(key.slice(0, 32)),
       /Expected Uint8Array with byteLength/
     )
 
-    const malformed = new Uint8Array(keys[id])
+    const malformed = new Uint8Array(key)
     // @ts-ignore
     varint.encodeTo(4, malformed, Signer.PUB_KEY_OFFSET)
 
@@ -90,21 +106,34 @@ describe('signing principal', () => {
   })
 
   it('SigningPrincipal decode encode roundtrip', async () => {
-    const signer = await Lib.generate()
+    const signer = await Lib.generate({ extractable: true })
 
     assert.deepEqual(Signer.decode(Signer.encode(signer)), signer)
   })
 
   it('SigningPrincipal.format', async () => {
-    const signer = await Lib.generate()
+    const signer = await Lib.generate({ extractable: true })
 
     assert.deepEqual(Signer.parse(Signer.format(signer)), signer)
   })
 
   it('SigningPrincipal.did', async () => {
-    const signer = await Lib.generate()
+    const signer = await Lib.generate({ extractable: true })
 
     assert.equal(signer.did().startsWith('did:key:'), true)
+  })
+
+  it('extractable signer supports Signer interface helpers', async () => {
+    const signer = await Lib.generate({ extractable: true })
+    const alias = signer.withDID('did:web:example.com')
+    const payload = new TextEncoder().encode('hello world')
+    const signature = await signer.sign(payload)
+
+    assert.equal(signer.code, 0x1300)
+    assert.equal(signer.signer, signer)
+    assert.equal(signer.toDIDKey(), signer.did())
+    assert.equal(signer.signatureAlgorithm, 'EdDSA')
+    assert.equal(await alias.verify(payload, signature), true)
   })
 })
 
@@ -118,10 +147,13 @@ describe('principal', () => {
   })
 
   it('Verifier.parse', async () => {
-    const signer = await Lib.generate()
+    const signer = await Lib.generate({ extractable: true })
     const verifier = Verifier.parse(signer.did())
     const { id, keys } = signer.toArchive()
     const bytes = keys[id]
+    if (!(bytes instanceof Uint8Array)) {
+      return assert.fail('Expected archive key to be Uint8Array')
+    }
 
     assert.deepEqual(
       new Uint8Array(bytes.buffer, bytes.byteOffset + Signer.PUB_KEY_OFFSET),
@@ -131,9 +163,12 @@ describe('principal', () => {
   })
 
   it('Verifier.decode', async () => {
-    const signer = await Lib.generate()
+    const signer = await Lib.generate({ extractable: true })
     const { id, keys } = signer.toArchive()
     const bytes = keys[id]
+    if (!(bytes instanceof Uint8Array)) {
+      return assert.fail('Expected archive key to be Uint8Array')
+    }
 
     const verifier = new Uint8Array(
       bytes.buffer,
@@ -149,7 +184,7 @@ describe('principal', () => {
   })
 
   it('Verifier.format', async () => {
-    const signer = await Lib.generate()
+    const signer = await Lib.generate({ extractable: true })
     const verifier = Verifier.parse(signer.did())
 
     assert.deepEqual(Verifier.format(verifier), signer.did())
@@ -163,7 +198,7 @@ describe('principal', () => {
   })
 
   it('signer toArchive', async () => {
-    const signer = await Lib.generate()
+    const signer = await Lib.generate({ extractable: true })
 
     assert.deepEqual(
       {
@@ -191,5 +226,32 @@ describe('principal', () => {
 
     const payload = new TextEncoder().encode('hello world')
     assert.equal(await ed.verify(payload, await ed.sign(payload)), true)
+  })
+
+  it('can archive and restore non extractable key', async () => {
+    const signer = await Lib.generate()
+    const archive = signer.toArchive()
+    const restored = Signer.from(archive)
+    const payload = new TextEncoder().encode('hello world')
+
+    const signature = await restored.sign(payload)
+    assert.equal(await signer.verify(payload, signature), true)
+    assert.equal(await restored.verify(payload, signature), true)
+
+    const key = /** @type {CryptoKey} */ (archive.keys[archive.id])
+    try {
+      await webcrypto.subtle.exportKey('pkcs8', key)
+      assert.fail('Expected exportKey(pkcs8) to fail for non extractable key')
+    } catch (error) {
+      assert.match(String(error), /extractable/i)
+    }
+  })
+
+  it('can not encode non extractable key', async () => {
+    const signer = await Lib.generate()
+    assert.throws(
+      () => Signer.encode(signer),
+      /Unextractable ed25519 key can not be encoded/
+    )
   })
 })

--- a/packages/server/test/readme-examples.spec.js
+++ b/packages/server/test/readme-examples.spec.js
@@ -55,7 +55,7 @@ test('README service definition works', async () => {
 // Test that ed25519.parse works 
 test('README uses correct ed25519.parse API', async () => {
   // This should work with the current API (not the old ed25519.Signer.parse)
-  const key = await ed25519.generate()
+  const key = await ed25519.generate({ extractable: true })
   
   // Test that we can format and parse keys correctly
   const formatted = ed25519.format(key)

--- a/packages/server/test/server.spec.js
+++ b/packages/server/test/server.spec.js
@@ -278,6 +278,9 @@ test('execution error', async () => {
   })
 
   const receipt = await boom.execute(connection)
+  if (!receipt.issuer) {
+    throw new Error('Expected receipt issuer')
+  }
   assert.equal(receipt.issuer.did(), w3.did())
 
   assert.containSubset(receipt, {

--- a/packages/server/test/server.spec.js
+++ b/packages/server/test/server.spec.js
@@ -278,9 +278,9 @@ test('execution error', async () => {
   })
 
   const receipt = await boom.execute(connection)
+  assert.equal(receipt.issuer.did(), w3.did())
 
   assert.containSubset(receipt, {
-    issuer: w3.verifier,
     out: {
       error: {
         error: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,9 +137,6 @@ importers:
       '@noble/curves':
         specifier: ^1.2.0
         version: 1.8.1
-      '@noble/ed25519':
-        specifier: ^1.7.3
-        version: 1.7.3
       '@noble/hashes':
         specifier: ^1.3.2
         version: 1.7.1
@@ -591,9 +588,6 @@ packages:
   '@noble/curves@1.8.1':
     resolution: {integrity: sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ==}
     engines: {node: ^14.21.3 || >=16}
-
-  '@noble/ed25519@1.7.3':
-    resolution: {integrity: sha512-iR8GBkDt0Q3GyaVcIu7mSsVIqnFbkbRzGLWlvhwunacoLwt4J3swfKhfaM6rN6WY+TBGoYT1GtT1mIh2/jGbRQ==}
 
   '@noble/hashes@1.7.1':
     resolution: {integrity: sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==}
@@ -2324,8 +2318,6 @@ snapshots:
   '@noble/curves@1.8.1':
     dependencies:
       '@noble/hashes': 1.7.1
-
-  '@noble/ed25519@1.7.3': {}
 
   '@noble/hashes@1.7.1': {}
 


### PR DESCRIPTION
## Summary
- switch `@ucanto/principal` Ed25519 signer implementation to WebCrypto
- default Ed25519 `generate()` to non-extractable keys while preserving extractable mode when explicitly requested
- remove direct `@noble/ed25519` signing path from Ed25519 signer
- add PKCS8/JWK conversion logic for Ed25519 derive/generate extractable flows
- add coverage-focused tests for extractable/non-extractable behavior and error paths
- update server receipt assertion to compare issuer by DID to avoid brittle object-shape comparison

## Context
This aligns with storacha/upload-service#658, which requires browser agent key generation to move to non-extractable WebCrypto Ed25519 keys.

## Breaking Changes
⚠️ **Libs and tests which required extractable keys now have to explicitly request it with `generate({ extractable: true })`**

Previously, keys were extractable by default. Now:
- **Default behavior**: `generate()` produces non-extractable keys
- **Extractable keys**: Must explicitly use `generate({ extractable: true })`
- **Impact**: Code that relied on `.secret()` or `.encode()` access will need updates

## Remark
Many changes are just prettier formatting changes

---

Co-Authored-By: NiKrause